### PR TITLE
Docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM elixir:1.8.1
+
+# Install hex package manager
+# By using --force, we don’t need to type “Y” to confirm the installation
+RUN mix local.hex --force && mix local.rebar --force
+
+# Install:
+# npm for the assets folder
+# inotify-tools for phoenix
+# postgresql-client to connect with the remote db
+RUN apt-get update -yq \
+    && apt-get install curl gnupg -yq \
+    && curl -sL https://deb.nodesource.com/setup_10.x | bash \
+    && apt-get install nodejs inotify-tools postgresql-client -yq
+
+# Create the app directory
+RUN mkdir /app /app/assets
+WORKDIR /app
+
+# Install the mimio client
+RUN wget --quiet https://dl.minio.io/client/mc/release/linux-amd64/mc
+RUN chmod +x mc
+RUN echo $PWD
+
+# Get the Dependencies
+## Elixir
+COPY mix.* /app/
+RUN mix deps.get
+## npm
+COPY assets/package*.json /app/assets/
+WORKDIR /app/assets
+RUN npm install
+WORKDIR /app
+
+# copy the Elixir projects into it
+COPY . /app
+
+ENTRYPOINT [ "/bin/bash", "entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ WORKDIR /app/assets
 RUN npm install
 WORKDIR /app
 
-# copy the Elixir projects into it
+# copy the Elixir projects into it and compile what's there
 COPY . /app
+RUN mix compile
 
 ENTRYPOINT [ "/bin/bash", "entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ We are still in an exploration phase. Technically the foundation for hosting a p
 
 ## Development
 
+**Docker Deployment**
+
+If you just want to take a look at the project, you can deploy a ready-to-run stack with [docker-compose](https://docs.docker.com/compose/):
+
+```shell
+git clone https://github.com/podlove/radiator-spark
+cd radiator-spark
+docker-compose up
+```
+
 **Minio Setup**
 
 - [Install minio][minio-setup]

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :ex_aws,
 
 config :ex_aws, :s3,
   scheme: "http://",
-  host: "localhost",
+  host: System.get_env("MINIO_HOST") || "localhost",
   port: 9000
 
 config :ex_aws, :hackney_opts,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -71,5 +71,5 @@ config :radiator, Radiator.Repo,
   username: "postgres",
   password: "postgres",
   database: "radiator_dev",
-  hostname: "localhost",
+  hostname: System.get_env("POSTGRES_HOST") || "localhost",
   pool_size: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3"
+services:
+  minio:
+    image: minio/minio
+    ports:
+      - 9000:9000
+    environment:
+      # These are the default keys as you would find them in config/config.exs
+      - MINIO_ACCESS_KEY=IEKAZMUY3KX32CRJPE9R
+      - MINIO_SECRET_KEY=tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+    volumes:
+      - minio_data:/data
+      - minio_config:/root/.minio
+    command: minio server /data
+  db:
+    image: postgres
+    volumes:
+      - psql_db:/var/lib/postgresql
+  radiator:
+    build: .
+    ports:
+      - 4000:4000
+    depends_on:
+      - db
+      - minio
+    environment:
+      - POSTGRES_HOST=db
+      - MINIO_HOST=minio
+
+volumes:
+  minio_data:
+  minio_config:
+  psql_db:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,19 @@
+# Reference: https://medium.com/@hex337/running-a-phoenix-1-3-project-with-docker-compose-d82ab55e43cf
+
+# Wait for Postgres to become available
+until psql -h db -U "postgres" -c '\q' 2>/dev/null; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+# Ecto will migrate the db to the latest changes
+mix ecto.create
+mix ecto.migrate
+
+# Create a mimio bucket called "radiator" at our s3 mimic
+./mc config host add radiator http://minio:9000 IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+./mc mb radiator/radiator
+./mc policy public radiator/radiator
+
+# Start the Phoenix server
+mix phx.server


### PR DESCRIPTION
As mentioned on #Subscribe10, I added Docker support for radiator.

You should now be able to run `docker-compose up` from the freshly-cloned repository. With that, three containers (a PostgreSQL, a Minio and finally radiator) will spin up.

**Todo:**

- [x] Docker files
- [x] Mention dockerbility in `/README.md`
- [ ] .dockerignore
- [ ] Add a travis-CI check (which would also help us detect if deployment works at all when a new PR comes in) **I've never worked with travis and would need some help for that**