### PR TITLE
feat(api,auth,perm): add api to generate access token with credentials, use these credentials in an api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ Entrypoint: `/api/graphql`
 
 Open http://localhost:4000/api/graphiql for schema and documentation exploration.
 
+For calls that need authentication, make sure to put the token gotten from a 
+
+```GraphQL
+mutation { 
+	authenticatedSession(
+		username_or_email: "admin", 
+		         password: "password" ) { 
+		token 
+	} 
+}
+```
+
+request into the `Authorization: Bearer <token>` header.
+
 ### REST
 
 Follows [HAL][hal]+json specification.

--- a/lib/radiator/auth/guardian.ex
+++ b/lib/radiator/auth/guardian.ex
@@ -4,6 +4,18 @@ defmodule Radiator.Auth.Guardian do
 
   alias Radiator.Auth
 
+  @doc """
+  Generates and returns a Bearer token for api usage.
+  """
+  def api_session_token(%Auth.User{} = user) do
+    {:ok, token, _tokenparams} = encode_and_sign(user, %{}, ttl: {45, :minutes})
+
+    token
+  end
+
+  # Callbacks
+
+  @impl Guardian
   def subject_for_token(%Auth.User{} = resource, _claims) do
     # You can use any value for the subject of your token but
     # it should be useful in retrieving the resource later, see
@@ -14,10 +26,12 @@ defmodule Radiator.Auth.Guardian do
     {:ok, sub}
   end
 
+  @impl Guardian
   def subject_for_token(_, _) do
     {:error, :reason_for_error}
   end
 
+  @impl Guardian
   def resource_from_claims(claims) when is_map(claims) do
     # Here we'll look up our resource from the claims, the subject can be
     # found in the `"sub"` key. In `above subject_for_token/2` we returned
@@ -33,6 +47,7 @@ defmodule Radiator.Auth.Guardian do
     end
   end
 
+  @impl Guardian
   def resource_from_claims(_claims) do
     {:error, :reason_for_error}
   end

--- a/lib/radiator_web/plug/validate_api_user.ex
+++ b/lib/radiator_web/plug/validate_api_user.ex
@@ -19,7 +19,7 @@ defmodule RadiatorWeb.Plug.ValidateAPIUser do
 
   defp build_context(conn) do
     with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
-         {:ok, claims} <- Auth.Guardian.decode_and_verify(token),
+         {:ok, claims = %{"typ" => "api_session"}} <- Auth.Guardian.decode_and_verify(token),
          {:ok, valid_user} <- Auth.Guardian.resource_from_claims(claims) do
       %{authenticated_user: valid_user}
     else

--- a/lib/radiator_web/plug/validate_api_user.ex
+++ b/lib/radiator_web/plug/validate_api_user.ex
@@ -1,0 +1,29 @@
+defmodule RadiatorWeb.Plug.ValidateAPIUser do
+  @moduledoc """
+  Put `:authenticated_user` into the `:context` map for GraphQL absinth if a valid bearer token is present.
+  """
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias Radiator.Auth
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _) do
+    conn
+    |> Absinthe.Plug.put_options(context: build_context(conn))
+  end
+
+  defp build_context(conn) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         {:ok, claims} <- Auth.Guardian.decode_and_verify(token),
+         {:ok, valid_user} <- Auth.Guardian.resource_from_claims(claims) do
+      %{authenticated_user: valid_user}
+    else
+      _ -> %{}
+    end
+  end
+end

--- a/lib/radiator_web/resolvers/editor.ex
+++ b/lib/radiator_web/resolvers/editor.ex
@@ -1,0 +1,10 @@
+defmodule RadiatorWeb.Resolvers.Editor do
+  alias Radiator.Directory.Editor
+
+  def create_network(_parent, %{network: args}, %{context: %{authenticated_user: user}}) do
+    case Editor.Owner.create_network(user, args) do
+      {:ok, %{network: network}} -> {:ok, network}
+      _ -> {:error, "Could not create network with #{args}"}
+    end
+  end
+end

--- a/lib/radiator_web/resolvers/session.ex
+++ b/lib/radiator_web/resolvers/session.ex
@@ -1,0 +1,22 @@
+defmodule RadiatorWeb.Resolvers.Session do
+  def get_authenticated_session(
+        _parent,
+        %{username_or_email: username_or_email, password: password},
+        _resolution
+      ) do
+    case Radiator.Auth.Register.get_user_by_credentials(username_or_email, password) do
+      nil ->
+        {:error, "Invalid credentials"}
+
+      valid_user ->
+        {:ok, token, _tokeninfo} =
+          Radiator.Auth.Guardian.encode_and_sign(valid_user, %{}, ttl: {45, :minutes})
+
+        {:ok,
+         %{
+           username: valid_user.name,
+           token: token
+         }}
+    end
+  end
+end

--- a/lib/radiator_web/resolvers/session.ex
+++ b/lib/radiator_web/resolvers/session.ex
@@ -18,4 +18,14 @@ defmodule RadiatorWeb.Resolvers.Session do
          }}
     end
   end
+
+  def prolong_authenticated_session(_parent, _params, %{context: %{authenticated_user: user}}) do
+    token = Radiator.Auth.Guardian.api_session_token(user)
+
+    {:ok,
+     %{
+       username: user.name,
+       token: token
+     }}
+  end
 end

--- a/lib/radiator_web/resolvers/session.ex
+++ b/lib/radiator_web/resolvers/session.ex
@@ -9,8 +9,7 @@ defmodule RadiatorWeb.Resolvers.Session do
         {:error, "Invalid credentials"}
 
       valid_user ->
-        {:ok, token, _tokeninfo} =
-          Radiator.Auth.Guardian.encode_and_sign(valid_user, %{}, ttl: {45, :minutes})
+        token = Radiator.Auth.Guardian.api_session_token(valid_user)
 
         {:ok,
          %{

--- a/lib/radiator_web/router.ex
+++ b/lib/radiator_web/router.ex
@@ -28,6 +28,7 @@ defmodule RadiatorWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug CORSPlug
+    plug RadiatorWeb.Plug.ValidateAPIUser
   end
 
   scope "/", RadiatorWeb do

--- a/lib/radiator_web/schema.ex
+++ b/lib/radiator_web/schema.ex
@@ -33,8 +33,10 @@ defmodule RadiatorWeb.Schema do
   import_types RadiatorWeb.Schema.Directory.EpisodeTypes
   import_types RadiatorWeb.Schema.DirectoryTypes
   import_types RadiatorWeb.Schema.StorageTypes
+  import_types RadiatorWeb.Schema.UserTypes
 
   alias RadiatorWeb.Resolvers
+  alias RadiatorWeb.Schema.Middleware, as: RadiatorWebMiddleware
 
   query do
     @desc "Get all podcasts"
@@ -70,12 +72,20 @@ defmodule RadiatorWeb.Schema do
   end
 
   mutation do
+    @desc "Request a authenticated session"
+    field :authenticated_session, :session do
+      arg :username_or_email, non_null(:string)
+      arg :password, non_null(:string)
+      resolve &Resolvers.Session.get_authenticated_session/3
+    end
+
     @desc "Create a network"
     field :create_network, type: :network do
       arg :network, non_null(:network_input)
+      middleware RadiatorWebMiddleware.RequireAuthentication
 
-      resolve &Resolvers.Directory.create_network/3
-      middleware RadiatorWeb.ChangesetMiddleware
+      resolve &Resolvers.Editor.create_network/3
+      middleware RadiatorWebMiddleware.TranslateChangeset
     end
 
     @desc "Update a network"
@@ -84,7 +94,7 @@ defmodule RadiatorWeb.Schema do
       arg :network, non_null(:network_input)
 
       resolve &Resolvers.Directory.update_network/3
-      middleware RadiatorWeb.ChangesetMiddleware
+      middleware RadiatorWebMiddleware.TranslateChangeset
     end
 
     @desc "Create a podcast"
@@ -93,7 +103,7 @@ defmodule RadiatorWeb.Schema do
       arg :network_id, non_null(:integer)
 
       resolve &Resolvers.Directory.create_podcast/3
-      middleware RadiatorWeb.ChangesetMiddleware
+      middleware RadiatorWebMiddleware.TranslateChangeset
     end
 
     @desc "Publish podcast"
@@ -116,7 +126,7 @@ defmodule RadiatorWeb.Schema do
       arg :podcast, non_null(:podcast_input)
 
       resolve &Resolvers.Directory.update_podcast/3
-      middleware RadiatorWeb.ChangesetMiddleware
+      middleware RadiatorWebMiddleware.TranslateChangeset
     end
 
     @desc "Delete a podcast"
@@ -138,7 +148,7 @@ defmodule RadiatorWeb.Schema do
       arg :episode, non_null(:episode_input)
 
       resolve &Resolvers.Directory.create_episode/3
-      middleware RadiatorWeb.ChangesetMiddleware
+      middleware RadiatorWebMiddleware.TranslateChangeset
     end
 
     @desc "Update an episode"
@@ -147,7 +157,7 @@ defmodule RadiatorWeb.Schema do
       arg :episode, non_null(:episode_input)
 
       resolve &Resolvers.Directory.update_episode/3
-      middleware RadiatorWeb.ChangesetMiddleware
+      middleware RadiatorWebMiddleware.TranslateChangeset
     end
 
     @desc "Delete an episode"

--- a/lib/radiator_web/schema.ex
+++ b/lib/radiator_web/schema.ex
@@ -72,14 +72,21 @@ defmodule RadiatorWeb.Schema do
   end
 
   mutation do
-    @desc "Request a authenticated session"
+    @desc "Request an authenticated session"
     field :authenticated_session, :session do
       arg :username_or_email, non_null(:string)
       arg :password, non_null(:string)
       resolve &Resolvers.Session.get_authenticated_session/3
     end
 
-    @desc "Create a network"
+    @desc "Prolong an authenticated session (Authenticated)"
+    field :prolong_session, :session do
+      middleware RadiatorWebMiddleware.RequireAuthentication
+
+      resolve &Resolvers.Session.prolong_authenticated_session/3
+    end
+
+    @desc "Create a network (Authenticated)"
     field :create_network, type: :network do
       arg :network, non_null(:network_input)
       middleware RadiatorWebMiddleware.RequireAuthentication

--- a/lib/radiator_web/schema/middleware/require_authentication.ex
+++ b/lib/radiator_web/schema/middleware/require_authentication.ex
@@ -1,0 +1,14 @@
+defmodule RadiatorWeb.Schema.Middleware.RequireAuthentication do
+  @behaviour Absinthe.Middleware
+
+  def call(resolution, _) do
+    case resolution.context do
+      %{authenticated_user: _} ->
+        resolution
+
+      _ ->
+        resolution
+        |> Absinthe.Resolution.put_result({:error, "Authentication: Needs authenticated user."})
+    end
+  end
+end

--- a/lib/radiator_web/schema/middleware/translate_changeset.ex
+++ b/lib/radiator_web/schema/middleware/translate_changeset.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.ChangesetMiddleware do
+defmodule RadiatorWeb.Schema.Middleware.TranslateChangeset do
   @behaviour Absinthe.Middleware
 
   def call(%Absinthe.Resolution{errors: errors} = resolution, _config)

--- a/lib/radiator_web/schema/user_types.ex
+++ b/lib/radiator_web/schema/user_types.ex
@@ -1,0 +1,9 @@
+defmodule RadiatorWeb.Schema.UserTypes do
+  use Absinthe.Schema.Notation
+
+  @desc "A user API session"
+  object :session do
+    field :username, :string
+    field :token, :string
+  end
+end

--- a/test/radiator_web/schema/mutation/networks_test.exs
+++ b/test/radiator_web/schema/mutation/networks_test.exs
@@ -13,6 +13,8 @@ defmodule RadiatorWeb.Schema.Mutation.NetworksTest do
   """
 
   test "createNetwork creates a network", %{conn: conn} do
+    conn = Radiator.TestEntries.put_authenticated_user(conn)
+
     network = params_for(:network)
 
     conn =
@@ -32,6 +34,21 @@ defmodule RadiatorWeb.Schema.Mutation.NetworksTest do
            } = json_response(conn, 200)
 
     refute is_nil(id)
+  end
+
+  test "createNetwork does not create a network when not authenticated", %{conn: conn} do
+    network = params_for(:network)
+
+    conn =
+      post conn, "/api/graphql",
+        query: @create_query,
+        variables: %{"network" => network}
+
+    assert %{
+             "errors" => [first_error]
+           } = json_response(conn, 200)
+
+    refute is_nil(first_error)
   end
 
   test "createNetwork returns error when missing data", %{conn: conn} do

--- a/test/radiator_web/schema/mutation/users_test.exs
+++ b/test/radiator_web/schema/mutation/users_test.exs
@@ -1,0 +1,36 @@
+defmodule RadiatorWeb.Schema.Mutation.UsersTest do
+  use RadiatorWeb.ConnCase, async: true
+
+  import Radiator.Factory
+
+  @request_session_query """
+  mutation ($username: String!, $password: String!) {
+    authenticatedSession(usernameOrEmail: $username, password: $password) {
+      token
+      username
+    }
+  }
+  """
+  test "autenticatedSession returns a session token for a valid user", %{conn: conn} do
+    username = Radiator.TestEntries.user().name
+
+    conn =
+      post conn, "/api/graphql",
+        query: @request_session_query,
+        variables: %{
+          "username" => username,
+          "password" => Radiator.TestEntries.user_password()
+        }
+
+    assert %{
+             "data" => %{
+               "authenticatedSession" => %{
+                 "username" => ^username,
+                 "token" => token
+               }
+             }
+           } = json_response(conn, 200)
+
+    assert {:ok, _tokenmap} = Radiator.Auth.Guardian.decode_and_verify(token)
+  end
+end

--- a/test/support/test_entries.ex
+++ b/test/support/test_entries.ex
@@ -1,6 +1,8 @@
 defmodule Radiator.TestEntries do
   alias Radiator.Auth
 
+  import Plug.Conn
+
   @testusername "TestUser1"
   @testuserpassword "Pass"
 
@@ -23,5 +25,13 @@ defmodule Radiator.TestEntries do
       user ->
         user
     end
+  end
+
+  def put_authenticated_user(conn, user \\ user()) do
+    conn
+    |> put_req_header(
+      "authorization",
+      "Bearer " <> Radiator.Auth.Guardian.api_session_token(user)
+    )
   end
 end

--- a/test/support/test_entries.ex
+++ b/test/support/test_entries.ex
@@ -4,6 +4,10 @@ defmodule Radiator.TestEntries do
   @testusername "TestUser1"
   @testuserpassword "Pass"
 
+  def user_password do
+    @testuserpassword
+  end
+
   def user do
     case Auth.Register.get_user_by_name(@testusername) do
       nil ->


### PR DESCRIPTION
* the `authenticatedSession` mutation now returns a `session` object with a token that needs to be put into the `Authorization:` header with a `Bearer ` prefix to have authenticated api calls.
* put Authentication in place for the `createNetwork` mutation. Default TTL is 45 minutes.
* add a `prolongSession` mutation to get a new token with full TTL to not need credentials again in a potential frontend app that is in use. 
* update `network_tests` to use this. 
* add `users_tests` for session related tests
* move middleware to `Radiator.Schema.Middleware`, rename `ChangesetMiddleware` to `Middleware.TranslateChangeset`

Fixes #45 
Fixes #46