### PR TITLE
chore(argon2_elixir): speed up password hashing during test

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -16,3 +16,6 @@ config :radiator, Radiator.Repo,
   database: "radiator_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+# Speed up password hashing during test
+config :argon2_elixir, t_cost: 1, m_cost: 8


### PR DESCRIPTION
should close #51 

> The following values can be used to speed up tests.
>
> ```elixir
>config :argon2_elixir,
>  t_cost: 1,
>  m_cost: 8
> ```

from [argon2_elixir docs](https://hexdocs.pm/argon2_elixir/Argon2.Stats.html#module-test-values)