### PR TITLE
Replace Travis CI with Drone CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,10 @@ steps:
   volumes:
   - name: mix
     path: /root/.mix
+  environment:
+    STORAGE_ASSET_HOST: "http://minio:9000/radiator"
+    STORAGE_HOST: "minio"
+    DB_HOST: "database"
   commands:
   - mix test
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,9 +12,9 @@ steps:
   image: minio/mc
   commands:
   - sleep 15
-  - config host add radiator minio IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
-  - mb radiator/radiator
-  - policy public radiator/radiator
+  - mc config host add radiator minio IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+  - mc mb radiator/radiator
+  - mc policy public radiator/radiator
 
 - name: install
   image: elixir:1.8

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
       from_secret: minio_secret_key
   commands:
   - sleep 5
-  - mc config host add radiator http://minio:9000 ${STORAGE_ACCESS_KEY} ${STORAGE_SECRET_KEY}
+  - mc config host add radiator http://minio:9000 $STORAGE_ACCESS_KEY $STORAGE_SECRET_KEY
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,9 +47,6 @@ services:
   image: minio/minio
   ports:
   - 9000
-  volumes:
-  - name: data
-    path: /mnt/data
   environment:
     MINIO_ACCESS_KEY: "IEKAZMUY3KX32CRJPE9R"
     MINIO_SECRET_KEY: "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN"
@@ -58,6 +55,3 @@ services:
 volumes:
 - name: mix
   temp: {}
-- name: data
-  host:
-    path: /mnt/data

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,14 +5,14 @@ steps:
 - name: setup-database
   image: postgres:9-alpine
   commands:
-  - sleep 5
+  - sleep 10
   - psql -U postgres -d radiator_test -h database
 
 - name: setup-minio
   image: minio/mc
   commands:
   - sleep 5
-  - mc config host add http://radiator:9000 minio IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+  - mc config host add radiator http://minio:9000 IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,14 +5,14 @@ steps:
 - name: setup-database
   image: postgres:9-alpine
   commands:
-  - sleep 15
+  - sleep 5
   - psql -U postgres -d radiator_test -h database
 
 - name: setup-minio
   image: minio/mc
   commands:
-  - sleep 15
-  - mc config host add radiator minio IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+  - sleep 5
+  - mc config host add http://radiator:9000 minio IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,13 +5,13 @@ steps:
 - name: setup-minio
   image: minio/mc
   environment:
-    MINIO_ACCESS_KEY:
+    STORAGE_ACCESS_KEY:
       from_secret: minio_access_key
-    MINIO_SECRET_KEY: 
+    STORAGE_SECRET_KEY: 
       from_secret: minio_secret_key
   commands:
   - sleep 5
-  - mc config host add radiator http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+  - mc config host add radiator http://minio:9000 $STORAGE_ACCESS_KEY $STORAGE_SECRET_KEY
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 
@@ -31,6 +31,10 @@ steps:
   - name: mix
     path: /root/.mix
   environment:
+    STORAGE_ACCESS_KEY:
+      from_secret: minio_access_key
+    STORAGE_SECRET_KEY: 
+      from_secret: minio_secret_key
     STORAGE_ASSET_HOST: "http://minio:9000/radiator"
     STORAGE_HOST: "minio"
     DB_HOST: "database"
@@ -51,9 +55,9 @@ services:
   ports:
   - 9000
   environment:
-    MINIO_ACCESS_KEY:
+    STORAGE_ACCESS_KEY:
       from_secret: minio_access_key
-    MINIO_SECRET_KEY: 
+    STORAGE_SECRET_KEY: 
       from_secret: minio_secret_key
   command: [ "server", "/data" ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,9 +4,14 @@ name: default
 steps:
 - name: setup-minio
   image: minio/mc
+  environment:
+    MINIO_ACCESS_KEY:
+      from_secret: minio_access_key
+    MINIO_SECRET_KEY: 
+      from_secret: minio_secret_key
   commands:
   - sleep 5
-  - mc config host add radiator http://minio:9000 IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+  - mc config host add radiator http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 
@@ -46,8 +51,10 @@ services:
   ports:
   - 9000
   environment:
-    MINIO_ACCESS_KEY: "IEKAZMUY3KX32CRJPE9R"
-    MINIO_SECRET_KEY: "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN"
+    MINIO_ACCESS_KEY:
+      from_secret: minio_access_key
+    MINIO_SECRET_KEY: 
+      from_secret: minio_secret_key
   command: [ "server", "/data" ]
 
 volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,7 @@ services:
   image: minio/minio
   ports:
   - 9000
-  command: [ "server" "/root/files" ]
+  command: [ "server", "/root/files" ]
   volumes:
   - name: files
     path: /root/files

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,14 +4,9 @@ name: default
 steps:
 - name: setup-minio
   image: minio/mc
-  environment:
-    MINIO_ACCESS_KEY:
-      from_secret: minio_access_key
-    MINIO_SECRET_KEY: 
-      from_secret: minio_secret_key
   commands:
   - sleep 5
-  - mc config host add radiator http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
+  - mc config host add radiator http://minio:9000 IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 
@@ -51,10 +46,8 @@ services:
   ports:
   - 9000
   environment:
-    MINIO_ACCESS_KEY:
-      from_secret: minio_access_key
-    MINIO_SECRET_KEY: 
-      from_secret: minio_secret_key
+    MINIO_ACCESS_KEY: "IEKAZMUY3KX32CRJPE9R"
+    MINIO_SECRET_KEY: "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN"
   command: [ "server", "/data" ]
 
 volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -35,12 +35,11 @@ services:
   environment:
     POSTGRES_USER: postgres
     POSTGRES_DB: radiator_test
-    
+
 - name: minio
   image: minio/minio
   ports:
   - 9000
-  entrypoint: [ minio ]
   command: [ "server /data" ]
 
 volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,13 +5,13 @@ steps:
 - name: setup-minio
   image: minio/mc
   environment:
-    STORAGE_ACCESS_KEY:
+    MINIO_ACCESS_KEY:
       from_secret: minio_access_key
-    STORAGE_SECRET_KEY: 
+    MINIO_SECRET_KEY: 
       from_secret: minio_secret_key
   commands:
   - sleep 5
-  - mc config host add radiator http://minio:9000 $STORAGE_ACCESS_KEY $STORAGE_SECRET_KEY
+  - mc config host add radiator http://minio:9000 $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 
@@ -31,10 +31,6 @@ steps:
   - name: mix
     path: /root/.mix
   environment:
-    STORAGE_ACCESS_KEY:
-      from_secret: minio_access_key
-    STORAGE_SECRET_KEY: 
-      from_secret: minio_secret_key
     STORAGE_ASSET_HOST: "http://minio:9000/radiator"
     STORAGE_HOST: "minio"
     DB_HOST: "database"
@@ -55,9 +51,9 @@ services:
   ports:
   - 9000
   environment:
-    STORAGE_ACCESS_KEY:
+    MINIO_ACCESS_KEY:
       from_secret: minio_access_key
-    STORAGE_SECRET_KEY: 
+    MINIO_SECRET_KEY: 
       from_secret: minio_secret_key
   command: [ "server", "/data" ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,10 +2,39 @@ kind: pipeline
 name: default
 
 steps:
-- name: test
+- name: setup
+  image: postgres:9-alpine
+  commands:
+  - sleep 15
+  - psql -U postgres -d radiator_test -h database
+
+- name: install
   image: elixir:1.8
+  volumes:
+  - name: mix
+    path: /root/.mix
   commands:
   - mix local.rebar --force
   - mix local.hex --force
   - mix deps.get
+
+- name: test
+  image: elixir:1.8
+  volumes:
+  - name: mix
+    path: /root/.mix
+  commands:
   - mix test
+
+services:
+- name: database
+  image: postgres:9-alpine
+  ports: 
+  - 5432
+  environment:
+    POSTGRES_USER: postgres
+    POSTGRES_DB: radiator_test
+
+volumes:
+- name: mix
+  temp: {}

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,12 +2,6 @@ kind: pipeline
 name: default
 
 steps:
-- name: setup-database
-  image: postgres:9-alpine
-  commands:
-  - sleep 10
-  - psql -U postgres -d radiator_test -h database
-
 - name: setup-minio
   image: minio/mc
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,8 +40,14 @@ services:
   image: minio/minio
   ports:
   - 9000
-  command: [ "server /data" ]
+  command: [ "server" "/root/files" ]
+  volumes:
+  - name: files
+    path: /root/files
 
 volumes:
 - name: mix
   temp: {}
+- name: files
+  host:
+    path: /root/files

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,11 @@
+kind: pipeline
+name: default
+
+steps:
+- name: test
+  image: elixir:1.8
+  commands:
+  - mix local.rebar --force
+  - mix local.hex --force
+  - mix deps.get
+  - mix test

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
       from_secret: minio_secret_key
   commands:
   - sleep 5
-  - mc config host add radiator http://minio:9000 $STORAGE_ACCESS_KEY $STORAGE_SECRET_KEY
+  - mc config host add radiator http://minio:9000 ${STORAGE_ACCESS_KEY} ${STORAGE_SECRET_KEY}
   - mc mb radiator/radiator
   - mc policy public radiator/radiator
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -40,14 +40,8 @@ services:
   image: minio/minio
   ports:
   - 9000
-  command: [ "server", "/root/files" ]
-  volumes:
-  - name: files
-    path: /root/files
+  command: [ "server", "/data" ]
 
 volumes:
 - name: mix
   temp: {}
-- name: files
-  host:
-    path: /root/files

--- a/.drone.yml
+++ b/.drone.yml
@@ -47,8 +47,17 @@ services:
   image: minio/minio
   ports:
   - 9000
+  volumes:
+  - name: data
+    path: /mnt/data
+  environment:
+    MINIO_ACCESS_KEY: "IEKAZMUY3KX32CRJPE9R"
+    MINIO_SECRET_KEY: "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN"
   command: [ "server", "/data" ]
 
 volumes:
 - name: mix
   temp: {}
+- name: data
+  host:
+    path: /mnt/data

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ kind: pipeline
 name: default
 
 steps:
-- name: setup
+- name: setup-database
   image: postgres:9-alpine
   commands:
   - sleep 15
@@ -17,6 +17,7 @@ steps:
   - mix local.rebar --force
   - mix local.hex --force
   - mix deps.get
+  - mix compile
 
 - name: test
   image: elixir:1.8
@@ -34,6 +35,13 @@ services:
   environment:
     POSTGRES_USER: postgres
     POSTGRES_DB: radiator_test
+    
+- name: minio
+  image: minio/minio
+  ports:
+  - 9000
+  entrypoint: [ minio ]
+  command: [ "server /data" ]
 
 volumes:
 - name: mix

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,14 @@ steps:
   - sleep 15
   - psql -U postgres -d radiator_test -h database
 
+- name: setup-minio
+  image: minio/mc
+  commands:
+  - sleep 15
+  - config host add radiator minio IEKAZMUY3KX32CRJPE9R tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
+  - mb radiator/radiator
+  - policy public radiator/radiator
+
 - name: install
   image: elixir:1.8
   volumes:
@@ -17,7 +25,6 @@ steps:
   - mix local.rebar --force
   - mix local.hex --force
   - mix deps.get
-  - mix compile
 
 - name: test
   image: elixir:1.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: elixir
-elixir: 1.8
-
-script:
-  - mix format --check-formatted
-  - mix test
-
-notifications:
-  slack: podlove:4oqpvB2KNDYwHCOp0qRJMR7H

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Radiator is the 100% open source podcast hosting project for the next century of the internet.
 
-[![Build Status](https://travis-ci.org/podlove/radiator.svg?branch=master)](https://travis-ci.org/podlove/radiator)
+[![Build Status](https://cloud.drone.io/api/badges/podlove/radiator/status.svg)](https://cloud.drone.io/podlove/radiator)
 
 ## Status
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -57,8 +57,9 @@ config :arc,
   asset_host: System.get_env("STORAGE_ASSET_HOST") || "http://localhost:9000/radiator"
 
 config :ex_aws,
-  access_key_id: "IEKAZMUY3KX32CRJPE9R",
-  secret_access_key: "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN",
+  access_key_id: System.get_env("STORAGE_ACCESS_KEY") || "IEKAZMUY3KX32CRJPE9R",
+  secret_access_key:
+    System.get_env("STORAGE_SECRET_KEY") || "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN",
   json_codec: Jason
 
 config :ex_aws, :s3,

--- a/config/config.exs
+++ b/config/config.exs
@@ -66,7 +66,7 @@ config :ex_aws,
 
 config :ex_aws, :s3,
   scheme: "http://",
-  host: "localhost",
+  host: "minio",
   port: 9000
 
 config :ex_aws, :hackney_opts,

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,7 +54,10 @@ config :arc,
   storage: Arc.Storage.S3,
   # if using Amazon S3
   bucket: "radiator",
-  asset_host: "http://localhost:9000/radiator"
+  # same here, find a way to dynamically have both drone and local working
+  asset_host: "http://minio:9000/radiator"
+
+# asset_host: "http://localhost:9000/radiator"
 
 config :ex_aws,
   access_key_id: "IEKAZMUY3KX32CRJPE9R",

--- a/config/config.exs
+++ b/config/config.exs
@@ -54,10 +54,7 @@ config :arc,
   storage: Arc.Storage.S3,
   # if using Amazon S3
   bucket: "radiator",
-  # same here, find a way to dynamically have both drone and local working
-  asset_host: "http://minio:9000/radiator"
-
-# asset_host: "http://localhost:9000/radiator"
+  asset_host: System.get_env("STORAGE_ASSET_HOST") || "http://localhost:9000/radiator"
 
 config :ex_aws,
   access_key_id: "IEKAZMUY3KX32CRJPE9R",
@@ -66,7 +63,7 @@ config :ex_aws,
 
 config :ex_aws, :s3,
   scheme: "http://",
-  host: "minio",
+  host: System.get_env("STORAGE_HOST") || "localhost",
   port: 9000
 
 config :ex_aws, :hackney_opts,

--- a/config/config.exs
+++ b/config/config.exs
@@ -57,9 +57,8 @@ config :arc,
   asset_host: System.get_env("STORAGE_ASSET_HOST") || "http://localhost:9000/radiator"
 
 config :ex_aws,
-  access_key_id: System.get_env("STORAGE_ACCESS_KEY") || "IEKAZMUY3KX32CRJPE9R",
-  secret_access_key:
-    System.get_env("STORAGE_SECRET_KEY") || "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN",
+  access_key_id: "IEKAZMUY3KX32CRJPE9R",
+  secret_access_key: "tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN",
   json_codec: Jason
 
 config :ex_aws, :s3,

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,6 +14,7 @@ config :radiator, Radiator.Repo,
   username: "postgres",
   password: "postgres",
   database: "radiator_test",
+  # "localhost" on local, "database" on drone -- can I read this from an env?
   hostname: "database",
   pool: Ecto.Adapters.SQL.Sandbox
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,6 @@ config :radiator, Radiator.Repo,
   username: "postgres",
   password: "postgres",
   database: "radiator_test",
-  # "localhost" on local, "database" on drone -- can I read this from an env?
   hostname: System.get_env("DB_HOST") || "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,7 +14,7 @@ config :radiator, Radiator.Repo,
   username: "postgres",
   password: "postgres",
   database: "radiator_test",
-  hostname: "localhost",
+  hostname: "database",
   pool: Ecto.Adapters.SQL.Sandbox
 
 # Speed up password hashing during test

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,7 @@ config :radiator, Radiator.Repo,
   password: "postgres",
   database: "radiator_test",
   # "localhost" on local, "database" on drone -- can I read this from an env?
-  hostname: "database",
+  hostname: System.get_env("DB_HOST") || "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
 
 # Speed up password hashing during test

--- a/notes.md
+++ b/notes.md
@@ -1,7 +1,5 @@
 # Radiator
 
-[![Build Status](https://travis-ci.org/podlove/radiator.svg?branch=master)](https://travis-ci.org/podlove/radiator)
-
 Quick project to get started and give the planned architecture a test drive.
 
 ## Show / Podcast


### PR DESCRIPTION
Reason: We now need minio to run for tests, which was a headscratcher with Travis but straightforward with Drone CI, suggested by @alexander-heimbuch 

https://cloud.drone.io/podlove/radiator