### PR TITLE
refactor: move all graphql modules into GraphQL namespace

### DIFF
--- a/lib/radiator_web/channels/user_socket.ex
+++ b/lib/radiator_web/channels/user_socket.ex
@@ -1,6 +1,6 @@
 defmodule RadiatorWeb.UserSocket do
   use Phoenix.Socket
-  use Absinthe.Phoenix.Socket, schema: RadiatorWeb.Schema
+  use Absinthe.Phoenix.Socket, schema: RadiatorWeb.GraphQL.Schema
 
   ## Channels
   # channel "room:*", RadiatorWeb.RoomChannel

--- a/lib/radiator_web/graphql/resolvers/directory.ex
+++ b/lib/radiator_web/graphql/resolvers/directory.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Resolvers.Directory do
+defmodule RadiatorWeb.GraphQL.Resolvers.Directory do
   alias Radiator.Directory
   alias Radiator.Directory.{Episode, Podcast, Network}
   alias Radiator.EpisodeMeta

--- a/lib/radiator_web/graphql/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/resolvers/editor.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Resolvers.Editor do
+defmodule RadiatorWeb.GraphQL.Resolvers.Editor do
   alias Radiator.Directory.Editor
 
   def create_network(_parent, %{network: args}, %{context: %{authenticated_user: user}}) do

--- a/lib/radiator_web/graphql/resolvers/session.ex
+++ b/lib/radiator_web/graphql/resolvers/session.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Resolvers.Session do
+defmodule RadiatorWeb.GraphQL.Resolvers.Session do
   def get_authenticated_session(
         _parent,
         %{username_or_email: username_or_email, password: password},

--- a/lib/radiator_web/graphql/resolvers/storage.ex
+++ b/lib/radiator_web/graphql/resolvers/storage.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Resolvers.Storage do
+defmodule RadiatorWeb.GraphQL.Resolvers.Storage do
   alias Radiator.Storage
   alias Radiator.Media
   alias Radiator.Directory

--- a/lib/radiator_web/graphql/schema.ex
+++ b/lib/radiator_web/graphql/schema.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema do
+defmodule RadiatorWeb.GraphQL.Schema do
   use Absinthe.Schema
 
   def plugins do
@@ -31,14 +31,14 @@ defmodule RadiatorWeb.Schema do
 
   import_types Absinthe.Type.Custom
   import_types Absinthe.Plug.Types
-  import_types RadiatorWeb.Schema.Directory.EpisodeTypes
-  import_types RadiatorWeb.Schema.DirectoryTypes
-  import_types RadiatorWeb.Schema.StorageTypes
-  import_types RadiatorWeb.Schema.MediaTypes
-  import_types RadiatorWeb.Schema.UserTypes
+  import_types RadiatorWeb.GraphQL.Schema.Directory.EpisodeTypes
+  import_types RadiatorWeb.GraphQL.Schema.DirectoryTypes
+  import_types RadiatorWeb.GraphQL.Schema.StorageTypes
+  import_types RadiatorWeb.GraphQL.Schema.MediaTypes
+  import_types RadiatorWeb.GraphQL.Schema.UserTypes
 
-  alias RadiatorWeb.Resolvers
-  alias RadiatorWeb.Schema.Middleware, as: RadiatorWebMiddleware
+  alias RadiatorWeb.GraphQL.Resolvers
+  alias RadiatorWeb.GraphQL.Schema.Middleware, as: RadiatorWebMiddleware
 
   query do
     @desc "Get all podcasts"

--- a/lib/radiator_web/graphql/schema/directory_types.ex
+++ b/lib/radiator_web/graphql/schema/directory_types.ex
@@ -1,9 +1,9 @@
-defmodule RadiatorWeb.Schema.DirectoryTypes do
+defmodule RadiatorWeb.GraphQL.Schema.DirectoryTypes do
   use Absinthe.Schema.Notation
 
   import Absinthe.Resolution.Helpers
 
-  alias RadiatorWeb.Resolvers
+  alias RadiatorWeb.GraphQL.Resolvers
 
   @desc "A network"
   object :network do

--- a/lib/radiator_web/graphql/schema/episode_types.ex
+++ b/lib/radiator_web/graphql/schema/episode_types.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.Directory.EpisodeTypes do
+defmodule RadiatorWeb.GraphQL.Schema.Directory.EpisodeTypes do
   use Absinthe.Schema.Notation
 
   @desc "A chapter in an episode"

--- a/lib/radiator_web/graphql/schema/media_types.ex
+++ b/lib/radiator_web/graphql/schema/media_types.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.MediaTypes do
+defmodule RadiatorWeb.GraphQL.Schema.MediaTypes do
   use Absinthe.Schema.Notation
 
   @desc "An audio enclosure"

--- a/lib/radiator_web/graphql/schema/middleware/require_authentication.ex
+++ b/lib/radiator_web/graphql/schema/middleware/require_authentication.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.Middleware.RequireAuthentication do
+defmodule RadiatorWeb.GraphQL.Schema.Middleware.RequireAuthentication do
   @behaviour Absinthe.Middleware
 
   def call(resolution, _) do

--- a/lib/radiator_web/graphql/schema/middleware/translate_changeset.ex
+++ b/lib/radiator_web/graphql/schema/middleware/translate_changeset.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.Middleware.TranslateChangeset do
+defmodule RadiatorWeb.GraphQL.Schema.Middleware.TranslateChangeset do
   @behaviour Absinthe.Middleware
 
   def call(%Absinthe.Resolution{errors: errors} = resolution, _config)

--- a/lib/radiator_web/graphql/schema/storage_types.ex
+++ b/lib/radiator_web/graphql/schema/storage_types.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.StorageTypes do
+defmodule RadiatorWeb.GraphQL.Schema.StorageTypes do
   use Absinthe.Schema.Notation
 
   @desc "Intermediary object providing an URL to upload against"

--- a/lib/radiator_web/graphql/schema/user_types.ex
+++ b/lib/radiator_web/graphql/schema/user_types.ex
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.UserTypes do
+defmodule RadiatorWeb.GraphQL.Schema.UserTypes do
   use Absinthe.Schema.Notation
 
   @desc "A user API session"

--- a/lib/radiator_web/router.ex
+++ b/lib/radiator_web/router.ex
@@ -81,7 +81,7 @@ defmodule RadiatorWeb.Router do
   scope "/api" do
     pipe_through :api
 
-    forward "/graphql", Absinthe.Plug, schema: RadiatorWeb.Schema
-    forward "/graphiql", Absinthe.Plug.GraphiQL, schema: RadiatorWeb.Schema
+    forward "/graphql", Absinthe.Plug, schema: RadiatorWeb.GraphQL.Schema
+    forward "/graphiql", Absinthe.Plug.GraphiQL, schema: RadiatorWeb.GraphQL.Schema
   end
 end

--- a/test/radiator_web/graphql/schema/mutation/episodes_test.exs
+++ b/test/radiator_web/graphql/schema/mutation/episodes_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.EpisodeControllerTest.Schema.Mutation.EpisodesTest do
+defmodule RadiatorWeb.GraphQL.Schema.Mutation.EpisodesTest do
   use RadiatorWeb.ConnCase, async: true
 
   import Radiator.Factory

--- a/test/radiator_web/graphql/schema/mutation/networks_test.exs
+++ b/test/radiator_web/graphql/schema/mutation/networks_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.Mutation.NetworksTest do
+defmodule RadiatorWeb.GraphQL.Schema.Mutation.NetworksTest do
   use RadiatorWeb.ConnCase, async: true
 
   import Radiator.Factory

--- a/test/radiator_web/graphql/schema/mutation/podcasts_test.exs
+++ b/test/radiator_web/graphql/schema/mutation/podcasts_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.EpisodeControllerTest.Schema.Mutation.PodcastsTest do
+defmodule RadiatorWeb.GraphQL.Schema.Mutation.PodcastsTest do
   use RadiatorWeb.ConnCase, async: true
 
   import Radiator.Factory

--- a/test/radiator_web/graphql/schema/mutation/upload_test.exs
+++ b/test/radiator_web/graphql/schema/mutation/upload_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.EpisodeControllerTest.Schema.Mutation.UploadTest do
+defmodule RadiatorWeb.GraphQL.Schema.Mutation.UploadTest do
   use RadiatorWeb.ConnCase, async: true
 
   import Radiator.Factory

--- a/test/radiator_web/graphql/schema/mutation/users_test.exs
+++ b/test/radiator_web/graphql/schema/mutation/users_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.Mutation.UsersTest do
+defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
   use RadiatorWeb.ConnCase, async: true
 
   @request_session_query """

--- a/test/radiator_web/graphql/schema/query/episodes_test.exs
+++ b/test/radiator_web/graphql/schema/query/episodes_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.EpisodeControllerTest.Schema.Query.EpisodesTest do
+defmodule RadiatorWeb.GraphQL.Schema.Query.EpisodesTest do
   use RadiatorWeb.ConnCase, async: true
   import Radiator.Factory
 

--- a/test/radiator_web/graphql/schema/query/networks_test.exs
+++ b/test/radiator_web/graphql/schema/query/networks_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.Schema.Query.NetworksTest do
+defmodule RadiatorWeb.GraphQL.Schema.Query.NetworksTest do
   use RadiatorWeb.ConnCase, async: true
   import Radiator.Factory
 

--- a/test/radiator_web/graphql/schema/query/podcasts_test.exs
+++ b/test/radiator_web/graphql/schema/query/podcasts_test.exs
@@ -1,4 +1,4 @@
-defmodule RadiatorWeb.EpisodeControllerTest.Schema.Query.PodcastsTest do
+defmodule RadiatorWeb.GraphQL.Schema.Query.PodcastsTest do
   use RadiatorWeb.ConnCase, async: true
 
   import Radiator.Factory


### PR DESCRIPTION
closes #34