### PR TITLE
Log emails to console in dev profile

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -74,3 +74,6 @@ config :radiator, Radiator.Repo,
   database: "radiator_dev",
   hostname: "localhost",
   pool_size: 10
+
+config :radiator, Radiator.Mailer,
+  adapter: Radiator.Email.Console

--- a/lib/radiator/email/email_console_adapter.ex
+++ b/lib/radiator/email/email_console_adapter.ex
@@ -1,0 +1,17 @@
+defmodule Radiator.Email.Console do
+  @moduledoc """
+  Bamboo Adapter that logs emails to console.
+  """
+  @behaviour Bamboo.Adapter
+
+  def deliver(email, _config) do
+    from_name= email.from |> elem(0)
+    from_email= email.from |> elem(1)
+    IO.puts("Mail sent to #{from_name} <#{from_email}> with subject: '#{email.subject}'")
+    IO.puts(email.text_body)
+  end
+
+  def handle_config(config), do: config
+
+  def supports_attachments?, do: true
+end

--- a/lib/radiator/email/email_console_adapter.ex
+++ b/lib/radiator/email/email_console_adapter.ex
@@ -8,8 +8,8 @@ defmodule Radiator.Email.Console do
   @behaviour Bamboo.Adapter
 
   def deliver(email, _config) do
-    from_name= email.from |> elem(0)
-    from_email= email.from |> elem(1)
+    from_name = email.from |> elem(0)
+    from_email = email.from |> elem(1)
     Logger.info("Mail sent to #{from_name} <#{from_email}> with subject: '#{email.subject}'")
     Logger.info(email.text_body)
   end

--- a/lib/radiator/email/email_console_adapter.ex
+++ b/lib/radiator/email/email_console_adapter.ex
@@ -2,13 +2,16 @@ defmodule Radiator.Email.Console do
   @moduledoc """
   Bamboo Adapter that logs emails to console.
   """
+
+  require Logger
+
   @behaviour Bamboo.Adapter
 
   def deliver(email, _config) do
     from_name= email.from |> elem(0)
     from_email= email.from |> elem(1)
-    IO.puts("Mail sent to #{from_name} <#{from_email}> with subject: '#{email.subject}'")
-    IO.puts(email.text_body)
+    Logger.info("Mail sent to #{from_name} <#{from_email}> with subject: '#{email.subject}'")
+    Logger.info(email.text_body)
   end
 
   def handle_config(config), do: config


### PR DESCRIPTION
This pr introduces a new Bamboo.Adapter which logs the emails to the console.
It also activates it for the dev profile.

The idea behind it is to be able to see the sent emails immediately in the console without having to configure an smtp server for development.

I'm absolutely new to Elixir and this tech stack. So if there are things completely wrong, please tell me.

I was not sure if i should use `IO.puts` to print to the console. But i didn't find other logging things in the project so i went with it.