### PR TITLE
feat(api,graphql): add episodesCount to podcast GraphQL queries

### DIFF
--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -71,24 +71,14 @@ defmodule Radiator.Directory do
   @doc """
   Gets the number of episodes of the podcast with the given id.
 
-  Raises `Ecto.NoResultsError` if the Podcast does not exist.
-
   ## Examples
 
       iex> get_episodes_count_for_podcast!(123)
       3
-
-      iex> get_podcast!(456)
-      ** (Ecto.NoResultsError)
-
   """
   def get_episodes_count_for_podcast!(id) do
-    %Podcast{id: ^id, episode_count: episode_count} =
-      from(p in Podcast, where: p.id == ^id)
-      |> Podcast.preload_episode_counts()
-      |> Repo.one!()
-
-    episode_count
+    from(e in Episode, where: e.podcast_id == ^id)
+    |> Repo.aggregate(:count, :id)
   end
 
   @doc """

--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -69,6 +69,29 @@ defmodule Radiator.Directory do
   def get_podcast(id), do: Repo.get(Podcast, id)
 
   @doc """
+  Gets the number of episodes of the podcast with the given id.
+
+  Raises `Ecto.NoResultsError` if the Podcast does not exist.
+
+  ## Examples
+
+      iex> get_episodes_count_for_podcast!(123)
+      3
+
+      iex> get_podcast!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_episodes_count_for_podcast!(id) do
+    %Podcast{id: ^id, episode_count: episode_count} =
+      from(p in Podcast, where: p.id == ^id)
+      |> Podcast.preload_episode_counts()
+      |> Repo.one!()
+
+    episode_count
+  end
+
+  @doc """
   Gets a single podcast by its slug.
 
   ## Examples

--- a/lib/radiator_web/graphql/resolvers/directory.ex
+++ b/lib/radiator_web/graphql/resolvers/directory.ex
@@ -183,4 +183,10 @@ defmodule RadiatorWeb.GraphQL.Resolvers.Directory do
   def get_image_url(network = %Network{}, _, _) do
     {:ok, Media.NetworkImage.url({network.image, network})}
   end
+
+  def get_episodes_count(%Podcast{id: podcast_id}, _, _) do
+    episodes_count = Directory.get_episodes_count_for_podcast!(podcast_id)
+
+    {:ok, episodes_count}
+  end
 end

--- a/lib/radiator_web/graphql/schema/directory_types.ex
+++ b/lib/radiator_web/graphql/schema/directory_types.ex
@@ -56,6 +56,10 @@ defmodule RadiatorWeb.GraphQL.Schema.DirectoryTypes do
 
       resolve dataloader(Radiator.Directory, :episodes)
     end
+
+    field :episodes_count, :integer do
+      resolve &Resolvers.Directory.get_episodes_count/3
+    end
   end
 
   @desc "The input for a podcast"

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -19,6 +19,18 @@ defmodule Radiator.DirectoryTest do
       assert Directory.get_podcast!(podcast.id) |> Repo.preload(:network) == podcast
     end
 
+    test "get_episodes_count_for_podcast!/1 return the number of episodes" do
+      podcast = insert(:podcast)
+
+      assert Directory.get_episodes_count_for_podcast!(podcast.id) == 0
+
+      _episode1 = insert(:episode, podcast: podcast)
+      _episode2 = insert(:episode, podcast: podcast)
+      _episode3 = insert(:episode, podcast: podcast)
+
+      assert Directory.get_episodes_count_for_podcast!(podcast.id) == 3
+    end
+
     test "get_podcast_by_slug/1 returns the podcast with given slug" do
       podcast = insert(:podcast, slug: "podcast-foo-bar-baz")
       assert Directory.get_podcast_by_slug(podcast.slug) |> Repo.preload(:network) == podcast

--- a/test/radiator_web/graphql/schema/query/podcasts_test.exs
+++ b/test/radiator_web/graphql/schema/query/podcasts_test.exs
@@ -100,4 +100,66 @@ defmodule RadiatorWeb.GraphQL.Schema.Query.PodcastsTest do
              }
     end
   end
+
+  describe "episodes" do
+    @with_episodes_query """
+    query ($id: ID!) {
+      podcast(id: $id) {
+        id
+        episodes {
+          id
+          title
+        }
+      }
+    }
+    """
+
+    test "returns all episodes of a podcast", %{conn: conn} do
+      podcast = insert(:podcast)
+      episode = insert(:episode, podcast: podcast)
+
+      conn =
+        get conn, "/api/graphql", query: @with_episodes_query, variables: %{"id" => podcast.id}
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "podcast" => %{
+                   "id" => Integer.to_string(podcast.id),
+                   "episodes" => [
+                     %{"id" => Integer.to_string(episode.id), "title" => episode.title}
+                   ]
+                 }
+               }
+             }
+    end
+  end
+
+  describe "episodes_count" do
+    @with_episodes_count_query """
+    query ($id: ID!) {
+      podcast(id: $id) {
+        id
+        episodesCount
+      }
+    }
+    """
+
+    test "returns the number of episodes associated to a podcast", %{conn: conn} do
+      podcast = insert(:podcast)
+      _episode1 = insert(:episode, podcast: podcast)
+      _episode2 = insert(:episode, podcast: podcast)
+      _episode3 = insert(:episode, podcast: podcast)
+
+      conn =
+        get conn, "/api/graphql",
+          query: @with_episodes_count_query,
+          variables: %{"id" => podcast.id}
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "podcast" => %{"id" => Integer.to_string(podcast.id), "episodesCount" => 3}
+               }
+             }
+    end
+  end
 end


### PR DESCRIPTION
I'm not too happy with making an extra database query to get the `episode_count`. Open to suggestions for a better idea. 😋

---

closes #62, when merged