### PR TITLE
fix: query enclosure of episode in gql

### DIFF
--- a/lib/radiator/directory/episode.ex
+++ b/lib/radiator/directory/episode.ex
@@ -52,6 +52,18 @@ defmodule Radiator.Directory.Episode do
   end
 
   @doc """
+  Get enclosure data for episode.
+  """
+  @spec enclosure(Episode.t()) :: %{url: binary(), type: binary(), length: integer()}
+  def enclosure(%Episode{} = episode) do
+    %{
+      url: enclosure_url(episode),
+      type: enclosure_mime_type(episode),
+      length: enclosure_byte_length(episode)
+    }
+  end
+
+  @doc """
   Convenience accessor for enclosure URL.
   """
   def enclosure_url(%Episode{audio: %Audio{audio_files: [enclosure]}}) do

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -272,16 +272,8 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     end
   end
 
-  # PERF: use data loader
-  def get_enclosure(%Episode{} = episode, _args, _resolution) do
-    episode = Radiator.Repo.preload(episode, :enclosure)
-
-    {:ok,
-     %{
-       url: Episode.enclosure_url(episode),
-       type: episode.enclosure.mime_type,
-       length: episode.enclosure.byte_length
-     }}
+  def get_enclosure(%Episode{} = episode, _args, %{context: %{authenticated_user: _user}}) do
+    {:ok, Episode.enclosure(episode)}
   end
 
   def get_chapters(%Audio{} = audio, _, _) do

--- a/lib/radiator_web/graphql/public/resolvers/directory.ex
+++ b/lib/radiator_web/graphql/public/resolvers/directory.ex
@@ -51,16 +51,8 @@ defmodule RadiatorWeb.GraphQL.Public.Resolvers.Directory do
     {:ok, AudioMeta.list_chapters(episode)}
   end
 
-  # PERF: use data loader
   def get_enclosure(%Episode{} = episode, _args, _resolution) do
-    episode = Radiator.Repo.preload(episode, :enclosure)
-
-    {:ok,
-     %{
-       url: Episode.enclosure_url(episode),
-       type: episode.enclosure.mime_type,
-       length: episode.enclosure.byte_length
-     }}
+    {:ok, Episode.enclosure(episode)}
   end
 
   def get_image_url(episode = %Episode{}, _, _) do

--- a/test/radiator_web/graphql/admin/schema/query/episodes_test.exs
+++ b/test/radiator_web/graphql/admin/schema/query/episodes_test.exs
@@ -3,6 +3,8 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
 
   import Radiator.Factory
 
+  alias Radiator.Directory.Episode
+
   @doc """
   Generate user and add auth token to connection.
   """
@@ -22,6 +24,11 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
     episode(id: $id) {
       id
       title
+      enclosure {
+        length
+        type
+        url
+      }
     }
   }
   """
@@ -29,12 +36,21 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
   test "episode returns an episode", %{conn: conn, user: user} do
     podcast = insert(:podcast) |> owned_by(user)
     episode = insert(:unpublished_episode, podcast: podcast)
+    enclosure = Episode.enclosure(episode)
 
     conn = get conn, "/api/graphql", query: @single_query, variables: %{"id" => episode.id}
 
     assert json_response(conn, 200) == %{
              "data" => %{
-               "episode" => %{"id" => Integer.to_string(episode.id), "title" => episode.title}
+               "episode" => %{
+                 "id" => Integer.to_string(episode.id),
+                 "title" => episode.title,
+                 "enclosure" => %{
+                   "length" => enclosure.length,
+                   "type" => enclosure.type,
+                   "url" => enclosure.url
+                 }
+               }
              }
            }
   end

--- a/test/radiator_web/graphql/public/schema/query/episodes_test.exs
+++ b/test/radiator_web/graphql/public/schema/query/episodes_test.exs
@@ -2,11 +2,18 @@ defmodule RadiatorWeb.GraphQL.Public.Schema.Query.EpisodesTest do
   use RadiatorWeb.ConnCase, async: true
   import Radiator.Factory
 
+  alias Radiator.Directory.Episode
+
   @single_query """
   query ($id: ID!) {
     episode(id: $id) {
       id
       title
+      enclosure {
+        length
+        type
+        url
+      }
     }
   }
   """
@@ -14,12 +21,21 @@ defmodule RadiatorWeb.GraphQL.Public.Schema.Query.EpisodesTest do
   test "episode returns an episode", %{conn: conn} do
     podcast = insert(:podcast)
     episode = insert(:published_episode, podcast: podcast)
+    enclosure = Episode.enclosure(episode)
 
     conn = get conn, "/api/graphql", query: @single_query, variables: %{"id" => episode.id}
 
     assert json_response(conn, 200) == %{
              "data" => %{
-               "episode" => %{"id" => Integer.to_string(episode.id), "title" => episode.title}
+               "episode" => %{
+                 "id" => Integer.to_string(episode.id),
+                 "title" => episode.title,
+                 "enclosure" => %{
+                   "length" => enclosure.length,
+                   "type" => enclosure.type,
+                   "url" => enclosure.url
+                 }
+               }
              }
            }
   end


### PR DESCRIPTION
fixes #102