### PR TITLE
feature(api): add `userSignup` to graphQL api

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -75,5 +75,4 @@ config :radiator, Radiator.Repo,
   hostname: System.get_env("POSTGRES_HOST") || "localhost",
   pool_size: 10
 
-config :radiator, Radiator.Mailer,
-  adapter: Radiator.Email.Console
+config :radiator, Radiator.Mailer, adapter: Radiator.Email.Console

--- a/config/test.exs
+++ b/config/test.exs
@@ -23,3 +23,5 @@ config :argon2_elixir, t_cost: 1, m_cost: 8
 config :arc,
   storage: Arc.Storage.S3,
   bucket: "radiator-test"
+
+config :radiator, Radiator.Mailer, adapter: Radiator.Email.Console

--- a/lib/radiator/auth/guardian.ex
+++ b/lib/radiator/auth/guardian.ex
@@ -14,6 +14,23 @@ defmodule Radiator.Auth.Guardian do
     token
   end
 
+  @doc """
+  Returns the expiry time of a token as `DateTime`. Returns value in the past if invalid or expired.
+  """
+  def get_expiry_datetime(token) do
+    {:ok, datetime} =
+      case Guardian.decode_and_verify(__MODULE__, token) do
+        {:ok, %{"exp" => expiry_timestamp}} ->
+          DateTime.from_unix(expiry_timestamp)
+
+        # treat as expired
+        _ ->
+          DateTime.from_unix(0)
+      end
+
+    datetime
+  end
+
   # Callbacks
 
   @impl Guardian

--- a/lib/radiator/auth/guardian.ex
+++ b/lib/radiator/auth/guardian.ex
@@ -54,9 +54,9 @@ defmodule Radiator.Auth.Guardian do
     # Here we'll look up our resource from the claims, the subject can be
     # found in the `"sub"` key. In `above subject_for_token/2` we returned
     # the resource id so here we'll rely on that to look it up.
-    id = claims["sub"]
+    username = claims["sub"]
 
-    case Radiator.Auth.Register.get_user_by_name(id) do
+    case Radiator.Auth.Register.get_user_by_name(username) do
       nil ->
         {:error, :resource_not_found}
 

--- a/lib/radiator/directory/importer.ex
+++ b/lib/radiator/directory/importer.ex
@@ -130,6 +130,7 @@ defmodule Radiator.Directory.Importer do
                 } ->
                   extension = hd(:mimerl.mime_to_exts(mime_type))
 
+                  # TODO: make a nice wrapper around this temporary file creation
                   upload = %Plug.Upload{
                     content_type: mime_type,
                     filename: "Chapter_#{index}.#{extension}",

--- a/lib/radiator_web/controllers/login_controller.ex
+++ b/lib/radiator_web/controllers/login_controller.ex
@@ -81,7 +81,7 @@ defmodule RadiatorWeb.LoginController do
     |> redirect(to: "/")
   end
 
-  defp email_configuration_url(conn, %Auth.User{} = user) do
+  def email_configuration_url(conn, %Auth.User{} = user) do
     Routes.login_url(
       conn,
       :verify_email,

--- a/lib/radiator_web/graphql/admin/resolvers/session.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/session.ex
@@ -1,5 +1,7 @@
 defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Session do
+  alias RadiatorWeb.GraphQL.Helpers.UserHelpers
+
   def prolong_authenticated_session(_parent, _params, %{context: %{authenticated_user: user}}) do
-    RadiatorWeb.GraphQL.Public.Resolvers.Session.new_session_for_valid_user(user)
+    UserHelpers.new_session_for_valid_user(user)
   end
 end

--- a/lib/radiator_web/graphql/admin/resolvers/session.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/session.ex
@@ -1,30 +1,5 @@
 defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Session do
-  import Radiator.Auth.Register, only: [get_user_by_credentials: 2]
-  import Radiator.Auth.Guardian, only: [api_session_token: 1]
-
-  def get_authenticated_session(
-        _parent,
-        %{username_or_email: username_or_email, password: password},
-        _resolution
-      ) do
-    case get_user_by_credentials(username_or_email, password) do
-      nil ->
-        {:error, "Invalid credentials"}
-
-      valid_user ->
-        {:ok,
-         %{
-           username: valid_user.name,
-           token: api_session_token(valid_user)
-         }}
-    end
-  end
-
   def prolong_authenticated_session(_parent, _params, %{context: %{authenticated_user: user}}) do
-    {:ok,
-     %{
-       username: user.name,
-       token: api_session_token(user)
-     }}
+    RadiatorWeb.GraphQL.Public.Resolvers.Session.new_session_for_valid_user(user)
   end
 end

--- a/lib/radiator_web/graphql/admin/resolvers/user.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/user.ex
@@ -1,0 +1,26 @@
+defmodule RadiatorWeb.GraphQL.Admin.Resolvers.User do
+  alias RadiatorWeb.GraphQL.Helpers.UserHelpers
+  alias Radiator.Auth
+
+  def resend_verification_email(_parent, _params, %{
+        context: context
+      }) do
+    case Map.get(context, :authenticated_user) do
+      %Auth.User{status: :unverified} = user ->
+        case UserHelpers.resend_verification_email_for_user(user, context) do
+          :sent ->
+            {:ok, true}
+
+          # Consideration: Maybe make it an error instead?
+          _ ->
+            {:ok, false}
+        end
+
+      _ ->
+        {
+          :error,
+          "Authenticiation: Needs authenticated unverified user."
+        }
+    end
+  end
+end

--- a/lib/radiator_web/graphql/admin/schema/middleware/require_authentication.ex
+++ b/lib/radiator_web/graphql/admin/schema/middleware/require_authentication.ex
@@ -3,8 +3,15 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Middleware.RequireAuthentication do
 
   def call(resolution, _) do
     case resolution.context do
-      %{authenticated_user: _} ->
-        resolution
+      %{authenticated_user: user} ->
+        case user.status do
+          :active ->
+            resolution
+
+          _ ->
+            resolution
+            |> Absinthe.Resolution.put_result({:error, "Authentication: Needs activated user."})
+        end
 
       _ ->
         resolution

--- a/lib/radiator_web/graphql/common/types.ex
+++ b/lib/radiator_web/graphql/common/types.ex
@@ -27,5 +27,6 @@ defmodule RadiatorWeb.GraphQL.Common.Types do
   object :session do
     field :username, :string
     field :token, :string
+    field :expires_at, :datetime
   end
 end

--- a/lib/radiator_web/graphql/helpers/user_helpers.ex
+++ b/lib/radiator_web/graphql/helpers/user_helpers.ex
@@ -1,0 +1,39 @@
+defmodule RadiatorWeb.GraphQL.Helpers.UserHelpers do
+  alias Radiator.Auth
+
+  @doc """
+  Construct session result type for user with newly created session.
+  """
+  def new_session_for_valid_user(user) do
+    token = Auth.Guardian.api_session_token(user)
+
+    {:ok,
+     %{
+       username: user.name,
+       token: token,
+       expires_at: Auth.Guardian.get_expiry_datetime(token)
+     }}
+  end
+
+  @doc """
+  Resend the verification email for a user
+  """
+  def resend_verification_email_for_user(user, resolution_context) do
+    case user.status do
+      :unverified ->
+        user
+        |> Auth.Email.email_verification_email(
+          RadiatorWeb.LoginController.email_configuration_url(
+            resolution_context.context_conn,
+            user
+          )
+        )
+        |> Radiator.Mailer.deliver_later()
+
+        :sent
+
+      _ ->
+        :not_sent
+    end
+  end
+end

--- a/lib/radiator_web/graphql/public/resolvers/session.ex
+++ b/lib/radiator_web/graphql/public/resolvers/session.ex
@@ -1,21 +1,28 @@
+alias Radiator.Auth
+
 defmodule RadiatorWeb.GraphQL.Public.Resolvers.Session do
   def get_authenticated_session(
         _parent,
         %{username_or_email: username_or_email, password: password},
         _resolution
       ) do
-    case Radiator.Auth.Register.get_user_by_credentials(username_or_email, password) do
+    case Auth.Register.get_user_by_credentials(username_or_email, password) do
       nil ->
         {:error, "Invalid credentials"}
 
       valid_user ->
-        token = Radiator.Auth.Guardian.api_session_token(valid_user)
-
-        {:ok,
-         %{
-           username: valid_user.name,
-           token: token
-         }}
+        new_session_for_valid_user(valid_user)
     end
+  end
+
+  def new_session_for_valid_user(user) do
+    token = Auth.Guardian.api_session_token(user)
+
+    {:ok,
+     %{
+       username: user.name,
+       token: token,
+       expires_at: Auth.Guardian.get_expiry_datetime(token)
+     }}
   end
 end

--- a/lib/radiator_web/graphql/public/resolvers/session.ex
+++ b/lib/radiator_web/graphql/public/resolvers/session.ex
@@ -15,7 +15,7 @@ defmodule RadiatorWeb.GraphQL.Public.Resolvers.Session do
     end
   end
 
-  def signup(
+  def user_signup(
         _parent,
         %{username: username, email: email, password: password},
         %{context: context}

--- a/lib/radiator_web/graphql/public/resolvers/user.ex
+++ b/lib/radiator_web/graphql/public/resolvers/user.ex
@@ -1,21 +1,7 @@
 alias Radiator.Auth
 alias RadiatorWeb.GraphQL.Helpers.UserHelpers
 
-defmodule RadiatorWeb.GraphQL.Public.Resolvers.Session do
-  def get_authenticated_session(
-        _parent,
-        %{username_or_email: username_or_email, password: password},
-        _resolution
-      ) do
-    case Auth.Register.get_user_by_credentials(username_or_email, password) do
-      nil ->
-        {:error, "Invalid credentials"}
-
-      valid_user ->
-        UserHelpers.new_session_for_valid_user(valid_user)
-    end
-  end
-
+defmodule RadiatorWeb.GraphQL.Public.Resolvers.User do
   def user_signup(
         _parent,
         %{username: username, email: email, password: password},

--- a/lib/radiator_web/graphql/schema.ex
+++ b/lib/radiator_web/graphql/schema.ex
@@ -122,11 +122,11 @@ defmodule RadiatorWeb.GraphQL.Schema do
 
   mutation do
     @desc "Sign up a user"
-    field :signup, :session do
+    field :user_signup, :session do
       arg :username, non_null(:string)
       arg :email, non_null(:string)
       arg :password, non_null(:string)
-      resolve &Public.Resolvers.Session.signup/3
+      resolve &Public.Resolvers.Session.user_signup/3
     end
 
     @desc "Request an authenticated session"

--- a/lib/radiator_web/graphql/schema.ex
+++ b/lib/radiator_web/graphql/schema.ex
@@ -129,6 +129,11 @@ defmodule RadiatorWeb.GraphQL.Schema do
       resolve &Public.Resolvers.Session.user_signup/3
     end
 
+    @desc "Request resend of verification email (need auth)"
+    field :user_resend_verification_email, :boolean do
+      resolve &Admin.Resolvers.User.resend_verification_email/3
+    end
+
     @desc "Request an authenticated session"
     field :authenticated_session, :session do
       arg :username_or_email, non_null(:string)
@@ -138,8 +143,6 @@ defmodule RadiatorWeb.GraphQL.Schema do
 
     @desc "Prolong an authenticated session"
     field :prolong_session, :session do
-      arg :username_or_email, non_null(:string)
-
       middleware Middleware.RequireAuthentication
       resolve &Admin.Resolvers.Session.prolong_authenticated_session/3
     end

--- a/lib/radiator_web/graphql/schema.ex
+++ b/lib/radiator_web/graphql/schema.ex
@@ -121,6 +121,14 @@ defmodule RadiatorWeb.GraphQL.Schema do
   end
 
   mutation do
+    @desc "Sign up a user"
+    field :signup, :session do
+      arg :username, non_null(:string)
+      arg :email, non_null(:string)
+      arg :password, non_null(:string)
+      resolve &Public.Resolvers.Session.signup/3
+    end
+
     @desc "Request an authenticated session"
     field :authenticated_session, :session do
       arg :username_or_email, non_null(:string)

--- a/lib/radiator_web/plug/validate_api_user.ex
+++ b/lib/radiator_web/plug/validate_api_user.ex
@@ -1,6 +1,8 @@
 defmodule RadiatorWeb.Plug.ValidateAPIUser do
   @moduledoc """
   Put `:authenticated_user` into the `:context` map for GraphQL absinthe if a valid bearer token is present.
+
+  Also put the the current state of the conn in context to enable URL generation for e.g. email templates and such.
   """
   @behaviour Plug
 
@@ -25,5 +27,6 @@ defmodule RadiatorWeb.Plug.ValidateAPIUser do
     else
       _ -> %{}
     end
+    |> Map.put(:context_conn, conn)
   end
 end

--- a/test/radiator_web/graphql/admin/schema/mutation/users_test.exs
+++ b/test/radiator_web/graphql/admin/schema/mutation/users_test.exs
@@ -1,6 +1,8 @@
 defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
   use RadiatorWeb.ConnCase, async: true
 
+  import Radiator.Factory
+
   @request_session_query """
   mutation ($username: String!, $password: String!) {
     authenticatedSession(usernameOrEmail: $username, password: $password) {
@@ -20,6 +22,110 @@ defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
     }
   }
   """
+
+  @signup_query """
+  mutation ($username: String!, $password: String!, $email: String!) {
+    signup(username: $username, email: $email, password: $password) {
+      token
+      username
+      expiresAt
+    }
+  }
+  """
+
+  test "signup returns a session token for a the created user", %{conn: conn} do
+    testusermap = params_for(:testuser)
+
+    username = testusermap.username
+    password = testusermap.password
+    email = testusermap.email
+
+    conn =
+      post conn, "/api/graphql",
+        query: @signup_query,
+        variables: %{
+          "username" => username,
+          "password" => password,
+          "email" => email
+        }
+
+    assert %{
+             "data" => %{
+               "signup" => %{
+                 "username" => ^username,
+                 "token" => token,
+                 "expiresAt" => expires_at
+               }
+             }
+           } = json_response(conn, 200)
+
+    {:ok, expiry_date, _} = DateTime.from_iso8601(expires_at)
+
+    user = Radiator.Auth.Register.get_user_by_credentials(username, password)
+    assert user.status == :unverified
+
+    assert :lt == DateTime.compare(DateTime.utc_now(), expiry_date)
+    assert {:ok, _tokenmap} = Radiator.Auth.Guardian.decode_and_verify(token)
+  end
+
+  test "authenticated signup returns a session token for a the created activated user", %{
+    conn: conn
+  } do
+    conn =
+      conn
+      |> post("/api/graphql",
+        query: @request_session_query,
+        variables: %{
+          "username" => Radiator.TestEntries.user().name,
+          "password" => Radiator.TestEntries.user_password()
+        }
+      )
+
+    assert %{
+             "data" => %{
+               "authenticatedSession" => %{
+                 "token" => token
+               }
+             }
+           } = json_response(conn, 200)
+
+    testusermap = params_for(:testuser)
+
+    username = testusermap.username
+    password = testusermap.password
+    email = testusermap.email
+
+    conn =
+      conn
+      |> recycle()
+      |> Plug.Conn.put_req_header("authorization", "Bearer #{token}")
+      |> post("/api/graphql",
+        query: @signup_query,
+        variables: %{
+          "username" => username,
+          "password" => password,
+          "email" => email
+        }
+      )
+
+    assert %{
+             "data" => %{
+               "signup" => %{
+                 "username" => ^username,
+                 "token" => token,
+                 "expiresAt" => expires_at
+               }
+             }
+           } = json_response(conn, 200)
+
+    {:ok, expiry_date, _} = DateTime.from_iso8601(expires_at)
+
+    user = Radiator.Auth.Register.get_user_by_credentials(username, password)
+    assert user.status == :active
+
+    assert :lt == DateTime.compare(DateTime.utc_now(), expiry_date)
+    assert {:ok, _tokenmap} = Radiator.Auth.Guardian.decode_and_verify(token)
+  end
 
   test "autenticatedSession returns a session token for a valid user", %{conn: conn} do
     username = Radiator.TestEntries.user().name

--- a/test/radiator_web/graphql/admin/schema/mutation/users_test.exs
+++ b/test/radiator_web/graphql/admin/schema/mutation/users_test.exs
@@ -25,7 +25,7 @@ defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
 
   @signup_query """
   mutation ($username: String!, $password: String!, $email: String!) {
-    signup(username: $username, email: $email, password: $password) {
+    userSignup(username: $username, email: $email, password: $password) {
       token
       username
       expiresAt
@@ -33,7 +33,7 @@ defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
   }
   """
 
-  test "signup returns a session token for a the created user", %{conn: conn} do
+  test "userSignup returns a session token for a the created user", %{conn: conn} do
     testusermap = params_for(:testuser)
 
     username = testusermap.username
@@ -51,7 +51,7 @@ defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
 
     assert %{
              "data" => %{
-               "signup" => %{
+               "userSignup" => %{
                  "username" => ^username,
                  "token" => token,
                  "expiresAt" => expires_at
@@ -68,7 +68,7 @@ defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
     assert {:ok, _tokenmap} = Radiator.Auth.Guardian.decode_and_verify(token)
   end
 
-  test "authenticated signup returns a session token for a the created activated user", %{
+  test "authenticated userSignup returns a session token for a the created activated user", %{
     conn: conn
   } do
     conn =
@@ -110,7 +110,7 @@ defmodule RadiatorWeb.GraphQL.Schema.Mutation.UsersTest do
 
     assert %{
              "data" => %{
-               "signup" => %{
+               "userSignup" => %{
                  "username" => ^username,
                  "token" => token,
                  "expiresAt" => expires_at

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,11 @@ defmodule Radiator.Factory do
     }
   end
 
+  def testuser_factory do
+    username = sequence("signup_test_user_")
+    %{username: username, password: sequence("pass_"), email: "#{username}@testhost.local"}
+  end
+
   # @deprecated use owned_by/2
   def make_owner(user = %User{}, network = %Network{}) do
     :ok = set_permission(user, network, :own)

--- a/test/support/test_entries.ex
+++ b/test/support/test_entries.ex
@@ -19,7 +19,9 @@ defmodule Radiator.TestEntries do
           password: "#{@testuserpassword}"
         })
         |> case do
-          {:ok, user} -> user
+          {:ok, user} ->
+            Auth.Register.activate_user(user)
+            user
         end
 
       user ->


### PR DESCRIPTION
feat(api): add expirydate to session result for `authenticatedSession` and `prolongSession`
fix(api): requiring active users now for admin api

fixes #75 