### PR TITLE
Issue/77 remove bangs

### DIFF
--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -126,27 +126,6 @@ defmodule Radiator.Directory do
     end)
   end
 
-  @doc """
-  Gets a single published episode.
-
-  Raises `Ecto.NoResultsError` if the Episode does not exist.
-
-  ## Examples
-
-      iex> get_episode!(123)
-      %Episode{}
-
-      iex> get_episode!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_episode!(id) do
-    Episode
-    |> EpisodeQuery.filter_by_published(true)
-    |> Repo.get!(id)
-    |> preload_for_episode()
-  end
-
   def get_episode(id) do
     Episode
     |> EpisodeQuery.filter_by_published(true)

--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -62,26 +62,6 @@ defmodule Radiator.Directory do
     |> Repo.all()
   end
 
-  @doc """
-  Gets a single podcast.
-
-  Raises `Ecto.NoResultsError` if the Podcast does not exist.
-
-  ## Examples
-
-      iex> get_podcast!(123)
-      %Podcast{}
-
-      iex> get_podcast!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_podcast!(id) do
-    Podcast
-    |> PodcastQuery.filter_by_published()
-    |> Repo.get!(id)
-  end
-
   def get_podcast(id) do
     Podcast
     |> PodcastQuery.filter_by_published()

--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -31,22 +31,6 @@ defmodule Radiator.Directory do
     Repo.all(Network)
   end
 
-  @doc """
-  Gets a single network.
-
-  Raises `Ecto.NoResultsError` if the Network does not exist.
-
-  ## Examples
-
-      iex> get_network!(123)
-      %Network{}
-
-      iex> get_network!(456)
-      ** (Ecto.NoResultsError)
-
-  """
-  def get_network!(id), do: Repo.get!(Network, id)
-
   def get_network(id), do: Repo.get(Network, id)
 
   @doc """

--- a/lib/radiator_web/controllers/api/episode_controller.ex
+++ b/lib/radiator_web/controllers/api/episode_controller.ex
@@ -8,14 +8,14 @@ defmodule RadiatorWeb.Api.EpisodeController do
   action_fallback RadiatorWeb.Api.FallbackController
 
   def index(conn, %{"podcast_id" => podcast_id}) do
-    with %Podcast{} = podcast <- Directory.get_podcast!(podcast_id),
+    with %Podcast{} = podcast <- Directory.get_podcast(podcast_id),
          episodes <- Directory.list_episodes(%{podcast: podcast}) do
       render(conn, "index.json", podcast: podcast, episodes: episodes)
     end
   end
 
   def create(conn, %{"podcast_id" => podcast_id, "episode" => episode_params}) do
-    with %Podcast{} = podcast <- Directory.get_podcast!(podcast_id),
+    with %Podcast{} = podcast <- Directory.get_podcast(podcast_id),
          {:ok, %Episode{} = episode} <- Editor.Manager.create_episode(podcast, episode_params) do
       conn
       |> put_status(:created)

--- a/lib/radiator_web/controllers/api/episode_controller.ex
+++ b/lib/radiator_web/controllers/api/episode_controller.ex
@@ -28,12 +28,16 @@ defmodule RadiatorWeb.Api.EpisodeController do
   end
 
   def show(conn, %{"id" => id}) do
-    episode = Directory.get_episode!(id) |> Directory.preload_for_episode()
-    render(conn, "show.json", episode: episode)
+    Directory.get_episode(id)
+    |> Directory.preload_for_episode()
+    |> case do
+      nil -> send_resp(conn, 404, "Not found")
+      episode -> render(conn, "show.json", episode: episode)
+    end
   end
 
   def update(conn, %{"id" => id, "episode" => episode_params}) do
-    episode = Directory.get_episode!(id)
+    episode = Directory.get_episode(id)
 
     with {:ok, %Episode{} = episode} <- Editor.Manager.update_episode(episode, episode_params) do
       render(conn, "show.json", episode: episode)
@@ -41,7 +45,7 @@ defmodule RadiatorWeb.Api.EpisodeController do
   end
 
   def delete(conn, %{"id" => id}) do
-    episode = Directory.get_episode!(id)
+    episode = Directory.get_episode(id)
 
     with {:ok, %Episode{}} <- Editor.Manager.delete_episode(episode) do
       send_resp(conn, :no_content, "")

--- a/lib/radiator_web/controllers/api/podcast_controller.ex
+++ b/lib/radiator_web/controllers/api/podcast_controller.ex
@@ -24,12 +24,14 @@ defmodule RadiatorWeb.Api.PodcastController do
   end
 
   def show(conn, %{"id" => id}) do
-    podcast = Directory.get_podcast!(id)
-    render(conn, "show.json", podcast: podcast)
+    case Directory.get_podcast(id) do
+      nil -> send_resp(conn, 404, "Not found")
+      podcast -> render(conn, "show.json", podcast: podcast)
+    end
   end
 
   def update(conn, %{"id" => id, "podcast" => podcast_params}) do
-    podcast = Directory.get_podcast!(id)
+    podcast = Directory.get_podcast(id)
 
     with {:ok, %Podcast{} = podcast} <- Editor.Manager.update_podcast(podcast, podcast_params) do
       render(conn, "show.json", podcast: podcast)
@@ -37,7 +39,7 @@ defmodule RadiatorWeb.Api.PodcastController do
   end
 
   def delete(conn, %{"id" => id}) do
-    podcast = Directory.get_podcast!(id)
+    podcast = Directory.get_podcast(id)
 
     with {:ok, %Podcast{}} <- Editor.Manager.delete_podcast(podcast) do
       send_resp(conn, :no_content, "")

--- a/lib/radiator_web/controllers/feed_controller.ex
+++ b/lib/radiator_web/controllers/feed_controller.ex
@@ -7,7 +7,7 @@ defmodule RadiatorWeb.FeedController do
   @items_per_page 50
 
   def show(conn, %{"podcast_id" => id, "page" => page}) do
-    podcast = Directory.get_podcast!(id)
+    podcast = Directory.get_podcast(id)
 
     episodes =
       Directory.list_episodes(%{podcast: podcast})

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -15,15 +15,13 @@ defmodule Radiator.DirectoryTest do
       assert Directory.list_podcasts() |> Repo.preload(:network) == [podcast]
     end
 
-    test "get_podcast!/1 returns the podcast with given id if it is public" do
+    test "get_podcast/1 returns the podcast with given id if it is public" do
       podcast = insert(:podcast)
-      assert Directory.get_podcast!(podcast.id) |> Repo.preload(:network) == podcast
+      assert Directory.get_podcast(podcast.id) |> Repo.preload(:network) == podcast
 
       podcast2 = insert(:unpublished_podcast)
 
-      assert_raise Ecto.NoResultsError, fn ->
-        Directory.get_podcast!(podcast2.id)
-      end
+      assert is_nil(Directory.get_podcast(podcast2.id))
     end
 
     test "get_episodes_count_for_podcast!/1 return the number of episodes" do
@@ -85,13 +83,13 @@ defmodule Radiator.DirectoryTest do
 
       assert {:error, %Ecto.Changeset{}} = Editor.Manager.update_podcast(podcast, %{title: nil})
 
-      assert podcast == Directory.get_podcast!(podcast.id) |> Repo.preload(:network)
+      assert podcast == Directory.get_podcast(podcast.id) |> Repo.preload(:network)
     end
 
     test "delete_podcast/1 deletes the podcast" do
       podcast = insert(:podcast)
       assert {:ok, %Podcast{}} = Editor.Manager.delete_podcast(podcast)
-      assert_raise Ecto.NoResultsError, fn -> Directory.get_podcast!(podcast.id) end
+      assert is_nil(Directory.get_podcast(podcast.id))
     end
 
     test "change_podcast/1 returns a podcast changeset" do
@@ -162,7 +160,7 @@ defmodule Radiator.DirectoryTest do
       assert {:error, %Ecto.Changeset{}} =
                Editor.Manager.depublish_podcast(%{podcast | :title => nil})
 
-      assert %Podcast{published_at: ^published_at} = Directory.get_podcast!(podcast.id)
+      assert %Podcast{published_at: ^published_at} = Directory.get_podcast(podcast.id)
     end
   end
 

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -178,11 +178,11 @@ defmodule Radiator.DirectoryTest do
       assert [%Episode{id: ^episode_id}] = Directory.list_episodes()
     end
 
-    test "get_episode!/1 returns the episode with given id" do
+    test "get_episode/1 returns the episode with given id" do
       episode = insert(:published_episode)
       episode_id = episode.id
 
-      assert %Episode{id: ^episode_id} = Directory.get_episode!(episode.id)
+      assert %Episode{id: ^episode_id} = Directory.get_episode(episode.id)
     end
 
     test "get_episode_by_slug/1 returns the episode with given slug" do
@@ -233,7 +233,7 @@ defmodule Radiator.DirectoryTest do
     test "delete_episode/1 deletes the episode" do
       episode = insert(:episode)
       assert {:ok, %Episode{}} = Editor.Manager.delete_episode(episode)
-      assert_raise Ecto.NoResultsError, fn -> Directory.get_episode!(episode.id) end
+      assert is_nil(Directory.get_episode(episode.id))
     end
 
     test "change_episode/1 returns an episode changeset" do
@@ -301,7 +301,7 @@ defmodule Radiator.DirectoryTest do
       assert {:error, %Ecto.Changeset{}} =
                Editor.Manager.depublish_episode(%{episode | :title => nil})
 
-      assert %Episode{published_at: ^published_at} = Directory.get_episode!(episode.id)
+      assert %Episode{published_at: ^published_at} = Directory.get_episode(episode.id)
     end
   end
 

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -328,9 +328,9 @@ defmodule Radiator.DirectoryTest do
       assert Directory.list_networks() == [network]
     end
 
-    test "get_network!/1 returns the network with given id" do
+    test "get_network/1 returns the network with given id" do
       network = network_fixture()
-      assert Directory.get_network!(network.id) == network
+      assert Directory.get_network(network.id) == network
     end
 
     test "get_network_by_slug/1 returns the network with given slug" do
@@ -372,13 +372,13 @@ defmodule Radiator.DirectoryTest do
     test "update_network/2 with invalid data returns error changeset" do
       network = network_fixture()
       assert {:error, %Ecto.Changeset{}} = Editor.Owner.update_network(network, @invalid_attrs)
-      assert network == Directory.get_network!(network.id)
+      assert network == Directory.get_network(network.id)
     end
 
     test "delete_network/1 deletes the network" do
       network = network_fixture()
       assert {:ok, %Network{}} = Editor.Owner.delete_network(network)
-      assert_raise Ecto.NoResultsError, fn -> Directory.get_network!(network.id) end
+      assert is_nil(Directory.get_network(network.id))
     end
   end
 

--- a/test/radiator_web/controllers/episode_controller_test.exs
+++ b/test/radiator_web/controllers/episode_controller_test.exs
@@ -178,15 +178,16 @@ defmodule RadiatorWeb.EpisodeControllerTest do
     setup [:create_episode]
 
     test "deletes chosen episode", %{conn: conn, episode: episode} do
+      podcast = fixture(:podcast)
+
       conn =
         delete(conn, Routes.api_podcast_episode_path(conn, :delete, episode.podcast.id, episode))
 
       assert response(conn, 204)
 
-      assert_error_sent 404, fn ->
-        podcast = fixture(:podcast)
-        get(conn, Routes.api_podcast_episode_path(conn, :show, podcast.id, episode))
-      end
+      conn = get(conn, Routes.api_podcast_episode_path(conn, :show, podcast.id, episode))
+
+      assert response(conn, 404)
     end
   end
 

--- a/test/radiator_web/controllers/podcast_controller_test.exs
+++ b/test/radiator_web/controllers/podcast_controller_test.exs
@@ -166,9 +166,8 @@ defmodule RadiatorWeb.PodcastControllerTest do
       conn = delete(conn, Routes.api_podcast_path(conn, :delete, podcast))
       assert response(conn, 204)
 
-      assert_error_sent 404, fn ->
-        get(conn, Routes.api_podcast_path(conn, :show, podcast))
-      end
+      conn = get(conn, Routes.api_podcast_path(conn, :show, podcast))
+      assert response(conn, 404)
     end
   end
 


### PR DESCRIPTION
Implemented as discussed but wondering now if that is such a good idea. Phoenix Controllers are designed in a way that raised errors are automatically convertet to appropriate HTTP responses, thereby simplifying controller logic. If we remove the bang getters, we need to implement these cases ourselves, in every controller method.

See https://github.com/podlove/radiator/blob/master/lib/radiator_web/controllers/api/fallback_controller.ex