### PR TITLE
Phoenix UI: improve episode form

### DIFF
--- a/lib/radiator/directory/editor/manager.ex
+++ b/lib/radiator/directory/editor/manager.ex
@@ -79,10 +79,25 @@ defmodule Radiator.Directory.Editor.Manager do
 
   """
   def create_episode(%Podcast{} = podcast, attrs \\ %{}) do
-    # always do it this way so the id is present in the validations
-    %Episode{podcast_id: podcast.id}
-    |> Episode.changeset(attrs)
-    |> Repo.insert()
+    # todo: keys are sometimes atoms, sometimes binaries? why? can/should we enforce atoms?
+    {update_attrs, insert_attrs} = Map.split(attrs, [:image, "image"])
+
+    insert =
+      Ecto.build_assoc(podcast, :episodes)
+      |> Episode.changeset(insert_attrs)
+
+    Multi.new()
+    |> Multi.insert(:episode, insert)
+    |> Multi.update(:episode_updated, fn %{episode: episode} ->
+      Episode.changeset(episode, update_attrs)
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{episode_updated: episode}} -> {:ok, episode}
+      {:error, :episode, changeset, _map} -> {:error, changeset}
+      {:error, :episode_updates, changeset, _map} -> {:error, changeset}
+      something -> something
+    end
   end
 
   @doc """

--- a/lib/radiator/directory/editor/manager.ex
+++ b/lib/radiator/directory/editor/manager.ex
@@ -80,7 +80,7 @@ defmodule Radiator.Directory.Editor.Manager do
   """
   def create_episode(%Podcast{} = podcast, attrs \\ %{}) do
     # todo: keys are sometimes atoms, sometimes binaries? why? can/should we enforce atoms?
-    {update_attrs, insert_attrs} = Map.split(attrs, [:image, "image"])
+    {update_attrs, insert_attrs} = Map.split(attrs, [:image, "image", :enclosure, "enclosure"])
 
     insert =
       Ecto.build_assoc(podcast, :episodes)

--- a/lib/radiator/media/audio_file_upload.ex
+++ b/lib/radiator/media/audio_file_upload.ex
@@ -62,7 +62,7 @@ defmodule Radiator.Media.AudioFileUpload do
   defp add_audio_file_changeset(upload = %Plug.Upload{path: path, filename: filename})
        when is_binary(path) and is_binary(filename) do
     {:ok, %File.Stat{size: size}} = File.lstat(path)
-    mime_type = MIME.from_path(path)
+    mime_type = MIME.from_path(path) |> fix_mime_type()
 
     fn %{create_audio_file: audio} ->
       AudioFile.changeset(audio, %{
@@ -75,7 +75,7 @@ defmodule Radiator.Media.AudioFileUpload do
   end
 
   defp add_audio_file_changeset(upload) when is_binary(upload) do
-    mime_type = MIME.from_path(upload)
+    mime_type = MIME.from_path(upload) |> fix_mime_type()
 
     # todo: get byte_length _after_ storing
 
@@ -88,6 +88,9 @@ defmodule Radiator.Media.AudioFileUpload do
       })
     end
   end
+
+  defp fix_mime_type("application/octet-stream"), do: "audio/mpeg"
+  defp fix_mime_type(mime), do: mime
 
   # Need to download first, otherwise the database transaction is not having fun and timing out
   def sideload(url, audio = %Audio{}) do

--- a/lib/radiator_web/controllers/admin/episode_controller.ex
+++ b/lib/radiator_web/controllers/admin/episode_controller.ex
@@ -5,8 +5,7 @@ defmodule RadiatorWeb.Admin.EpisodeController do
 
   alias Radiator.Storage
   alias Radiator.Directory
-  alias Radiator.Directory.Editor
-  alias Radiator.Directory.Episode
+  alias Radiator.Directory.{Editor, Episode, Audio}
   alias Radiator.Media.AudioFileUpload
 
   plug :assign_podcast when action in [:new, :create, :update]
@@ -30,9 +29,15 @@ defmodule RadiatorWeb.Admin.EpisodeController do
 
     case Editor.Manager.create_episode(podcast, episode_params) do
       {:ok, episode} ->
+        audio =
+          %Audio{} |> Ecto.Changeset.change(%{episodes: [episode]}) |> Radiator.Repo.insert!()
+
         if episode_params["enclosure"] do
-          {:ok, _audio} = AudioFileUpload.upload(episode_params["enclosure"], episode)
+          {:ok, _audio} = AudioFileUpload.upload(episode_params["enclosure"], audio)
         end
+
+        # temporary: publish immediately
+        Editor.Manager.publish_episode(episode)
 
         conn
         |> put_flash(:info, "episode created successfully.")

--- a/lib/radiator_web/controllers/admin/episode_controller.ex
+++ b/lib/radiator_web/controllers/admin/episode_controller.ex
@@ -29,6 +29,8 @@ defmodule RadiatorWeb.Admin.EpisodeController do
 
     case Editor.Manager.create_episode(podcast, episode_params) do
       {:ok, episode} ->
+        # todo: maybe add an "enclosure" virtual attribute to Episode,
+        #       and handle this upload logic through changeset?
         audio =
           %Audio{} |> Ecto.Changeset.change(%{episodes: [episode]}) |> Radiator.Repo.insert!()
 
@@ -81,6 +83,7 @@ defmodule RadiatorWeb.Admin.EpisodeController do
 
     {:ok, episode} = Editor.get_episode(user, id)
 
+    # fixme: broken, see create/2
     if episode_params["enclosure"] do
       {:ok, _audio} = AudioFileUpload.upload(episode_params["enclosure"], episode)
     end

--- a/lib/radiator_web/controllers/admin/episode_controller.ex
+++ b/lib/radiator_web/controllers/admin/episode_controller.ex
@@ -29,15 +29,6 @@ defmodule RadiatorWeb.Admin.EpisodeController do
 
     case Editor.Manager.create_episode(podcast, episode_params) do
       {:ok, episode} ->
-        # todo: maybe add an "enclosure" virtual attribute to Episode,
-        #       and handle this upload logic through changeset?
-        audio =
-          %Audio{} |> Ecto.Changeset.change(%{episodes: [episode]}) |> Radiator.Repo.insert!()
-
-        if episode_params["enclosure"] do
-          {:ok, _audio} = AudioFileUpload.upload(episode_params["enclosure"], audio)
-        end
-
         # temporary: publish immediately
         Editor.Manager.publish_episode(episode)
 
@@ -82,11 +73,6 @@ defmodule RadiatorWeb.Admin.EpisodeController do
     user = authenticated_user(conn)
 
     {:ok, episode} = Editor.get_episode(user, id)
-
-    # fixme: broken, see create/2
-    if episode_params["enclosure"] do
-      {:ok, _audio} = AudioFileUpload.upload(episode_params["enclosure"], episode)
-    end
 
     case Editor.Manager.update_episode(episode, episode_params) do
       {:ok, episode} ->

--- a/lib/radiator_web/templates/admin/episode/form.html.eex
+++ b/lib/radiator_web/templates/admin/episode/form.html.eex
@@ -23,6 +23,12 @@
     </div>
 
     <div class="mb-6">
+      <%= label f, :image, class: "font-bold text-sm text-gray-700 uppercase tracking-wider mb-2 block" %>
+      <%= file_input f, :image, rows: 3, class: "input" %>
+      <%= error_tag f, :image %>
+    </div>
+
+    <div class="mb-6">
       <%= label f, :enclosure, class: "font-bold text-sm text-gray-700 uppercase tracking-wider mb-2 block" %>
       <%= file_input f, :enclosure, rows: 3, class: "input" %>
       <%= error_tag f, :enclosure %>

--- a/lib/radiator_web/templates/admin/episode/form.html.eex
+++ b/lib/radiator_web/templates/admin/episode/form.html.eex
@@ -22,6 +22,12 @@
       <%= error_tag f, :description %>
     </div>
 
+    <div class="mb-6">
+      <%= label f, :enclosure, class: "font-bold text-sm text-gray-700 uppercase tracking-wider mb-2 block" %>
+      <%= file_input f, :enclosure, rows: 3, class: "input" %>
+      <%= error_tag f, :enclosure %>
+    </div>
+
     <%= submit @button_text, class: "btn btn-blue" %>
 <% end %>
 </div>

--- a/lib/radiator_web/templates/admin/episode/show.html.eex
+++ b/lib/radiator_web/templates/admin/episode/show.html.eex
@@ -36,7 +36,7 @@
     </script>
   <% end %>
 
-  <%= if @episode.audio.chapters do %>
+  <%= if @episode.audio.chapters && length(@episode.audio.chapters) > 0 do %>
     <div class="card max-w-sm flex flex-col mt-8">
       <span class="text-gray-700 font-normal text-lg mb-4">Chapters</span>
       <%= for {chapter, index} <- (@episode.audio.chapters |> Enum.with_index(1)) do %>


### PR DESCRIPTION
Add enough functionality to create usable episodes via Phoenix UI.

- reenable audio file upload
- publish episodes on creation (temporarily until there are publish buttons)
- fix mp3 upload mime type when necessary
- hide chapters if there are none
- support episode image in form
- move upload logic from controller to schema/changeset