### PR TITLE
fix(pheonix-ui): add a more consistent look and provide some help for the future

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -50,12 +50,14 @@ html {
  * @import "utilities/skew-transforms";
  */
 
+
+ /* used in svg icons that have 2 colors */
 .primary {
-  fill: #bcdefa;
+  fill: theme("colors.tertiary");
 }
 
 .secondary {
-  fill: #0D2B3E;
+  fill: theme("colors.primary");
 }
 
 .card {
@@ -70,33 +72,47 @@ html {
   }
 }
 
+.txt-lnk {
+  @apply no-underline text-primary;
+}
+
+.txt-lnk:hover {
+  @apply underline;
+}
+
 .btn {
-  @apply no-underline font-bold py-2 px-4 rounded;
+  @apply no-underline font-bold py-2 px-4 bg-primary text-white rounded;
 }
 
-.btn-blue {
-  @apply bg-blue-500 text-white;
+.btn:hover {
+  @apply bg-secondary;
 }
 
-.btn-blue:hover {
-  @apply bg-blue-600;
-}
-
-.btn-red {
+.btn-destructive {
   @apply bg-red-500 text-white;
 }
 
-.btn-red:hover {
+.btn-destructive:hover {
   @apply bg-red-600;
 }
 
-.pill {
-  @apply shadow bg-white text-blue-500 py-2 px-4 rounded-full;
-
-  &:hover {
-    @apply text-blue-700;
-  }
+.btn-cancel {
+  @apply text-gray-900 bg-gray-200 border-secondary border rounded;
 }
+
+.btn-cancel:hover {
+  @apply text-black bg-gray-300;
+}
+
+
+.pill {
+  @apply shadow bg-white text-primary py-2 px-4 rounded-full;
+}
+
+.pill:hover {
+  @apply text-secondary;
+}
+
 
 .nav-chevron {
   @apply mx-1 h-full flex items-center;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -104,6 +104,9 @@ html {
   @apply text-black bg-gray-300;
 }
 
+.btn-wicon {
+  @apply inline-flex items-center pl-3;
+}
 
 .pill {
   @apply shadow bg-white text-primary py-2 px-4 rounded-full;
@@ -119,23 +122,32 @@ html {
 }
 
 .nav-link {
-  @apply mx-1 h-full flex items-center;
+  @apply mx-0 h-full flex items-center;
 
   a {
     @apply text-gray-200 no-underline;
   }
 
-  &.active,
-  &:hover {
-    @apply border-b-4 border-gray-200;
+}
 
-    a {
-      position: relative;
-      top: 2px;
-    }
-  }
+.nav-link:hover {
+  @apply underline;
 }
 
 .help-block {
   @apply block text-red-600 mx-4 mt-2;
+}
+
+.truncate-fade {
+  @apply truncate;
+  position: relative;
+}
+.truncate-fade:after {
+  position: absolute;
+  content: "";
+  height: 100%;
+  bottom: 0;
+  right: 0;
+  width: 2em;
+  background: linear-gradient(to right,theme("colors.primarytransparent"), theme("colors.primary"));
 }

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -10,6 +10,11 @@ module.exports = {
       xl: '1280px',
     },
     colors: {
+      primary: '#2C6272',
+      secondary: '#5C9EB2',
+      tertiary: '#74B7C9',
+      highlight: '#B9E2ED',
+
       transparent: 'transparent',
 
       black: '#000',
@@ -221,9 +226,8 @@ module.exports = {
     },
     fontFamily: {
       sans: [
+        'Avenir Next',
         '-apple-system',
-        'BlinkMacSystemFont',
-        '"Segoe UI"',
         'Roboto',
         '"Helvetica Neue"',
         'Arial',

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
     },
     colors: {
       primary: '#2C6272',
+      primarytransparent: 'rgba(44, 98, 114, 0)',
       secondary: '#5C9EB2',
       tertiary: '#74B7C9',
       highlight: '#B9E2ED',

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -361,7 +361,8 @@ defmodule Radiator.Directory.Editor do
     end
   end
 
-  def get_episode_by_podcast_id_and_guid(user = %Auth.User{}, podcast_id, guid) do
+  def get_episode_by_podcast_id_and_guid(user = %Auth.User{}, podcast_id, guid)
+      when not is_nil(podcast_id) and not is_nil(guid) do
     query =
       from ep in Episode,
         where: ep.podcast_id == ^podcast_id,

--- a/lib/radiator_web.ex
+++ b/lib/radiator_web.ex
@@ -43,6 +43,8 @@ defmodule RadiatorWeb do
 
       import RadiatorWeb.ErrorHelpers
       import RadiatorWeb.Gettext
+      import RadiatorWeb.FormatHelpers
+
       alias RadiatorWeb.Router.Helpers, as: Routes
     end
   end

--- a/lib/radiator_web/controllers/admin/network_controller.ex
+++ b/lib/radiator_web/controllers/admin/network_controller.ex
@@ -22,12 +22,12 @@ defmodule RadiatorWeb.Admin.NetworkController do
     user = Guardian.Plug.current_resource(conn)
 
     case Editor.create_network(user, network_params) do
-      {:ok, network} ->
+      {:ok, %Network{} = network} ->
         conn
         |> put_flash(:info, "Network created successfully.")
         |> redirect(to: Routes.admin_network_path(conn, :show, network.id))
 
-      {:error, %Ecto.Changeset{} = changeset, _} ->
+      {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "new.html", changeset: changeset)
     end
   end

--- a/lib/radiator_web/controllers/player_controller.ex
+++ b/lib/radiator_web/controllers/player_controller.ex
@@ -80,7 +80,7 @@ defmodule RadiatorWeb.PlayerController do
   def chapters(%Audio{chapters: chapters}) do
     Enum.map(chapters, fn chapter ->
       %{
-        start: RadiatorWeb.Admin.EpisodeView.format_chapter_time(chapter.start),
+        start: RadiatorWeb.FormatHelpers.format_chapter_time(chapter.start),
         title: chapter.title,
         href: chapter.link,
         image: Chapter.image_url(chapter)

--- a/lib/radiator_web/templates/admin/episode/edit.html.eex
+++ b/lib/radiator_web/templates/admin/episode/edit.html.eex
@@ -4,5 +4,10 @@
       <span class="text-gray-600 font-normal text-lg">Changes can take a moment until they are visible on third party platforms.</span>
     </div>
 
-    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_podcast_episode_path(@conn, :update, @episode.podcast.network_id, @episode.podcast, @episode), button_text: "Update Episode"}) %>
+    <%= render "form.html", Map.merge(assigns, %{
+        action: Routes.admin_network_podcast_episode_path(@conn, :update, @episode.podcast.network_id, @episode.podcast, @episode), 
+        button_text: "Update Episode",
+        cancel_text: "Cancel",
+        cancel_url: Routes.admin_network_podcast_episode_path(@conn, :show, @episode.podcast.network_id, @episode.podcast, @episode)
+        }) %>
 </div>

--- a/lib/radiator_web/templates/admin/episode/form.html.eex
+++ b/lib/radiator_web/templates/admin/episode/form.html.eex
@@ -34,6 +34,11 @@
       <%= error_tag f, :enclosure %>
     </div>
 
-    <%= submit @button_text, class: "btn btn-blue" %>
+    <div class="flex">
+      <%= submit @button_text, class: "btn" %>
+      <%= if assigns[:cancel_url] do %>
+        <%= link @cancel_text, to: @cancel_url, class: "btn btn-cancel ml-2" %>
+      <% end %>
+    </div>
 <% end %>
 </div>

--- a/lib/radiator_web/templates/admin/episode/new.html.eex
+++ b/lib/radiator_web/templates/admin/episode/new.html.eex
@@ -4,5 +4,11 @@
       <span class="text-gray-600 font-normal text-lg">Let's add some META to your DATA.</span>
     </div>
 
-    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_podcast_episode_path(@conn, :create, @podcast.network_id, @podcast), button_text: "Create Episode"}) %>
+    <%= render "form.html", Map.merge(assigns, %{
+      action: Routes.admin_network_podcast_episode_path(@conn, :create, @podcast.network_id, @podcast), 
+      button_text: "Create Episode",
+      cancel_text: "Cancel",
+      cancel_url: Routes.admin_network_podcast_path(@conn, :show, @podcast.network_id, @podcast)
+    
+    }) %>
 </div>

--- a/lib/radiator_web/templates/admin/episode/show.html.eex
+++ b/lib/radiator_web/templates/admin/episode/show.html.eex
@@ -18,7 +18,7 @@
     </div>
     <div>
       <%= link to: Routes.admin_network_podcast_episode_path(@conn, :edit, @episode.podcast.network_id, @episode.podcast, @episode), class: "no-underline text-blue-500" do %>
-      <div class="shadow bg-white text-blue-500 py-2 px-4 rounded-full">
+      <div class="pill">
         edit
       </div>
       <% end %>

--- a/lib/radiator_web/templates/admin/network/edit.html.eex
+++ b/lib/radiator_web/templates/admin/network/edit.html.eex
@@ -4,5 +4,9 @@
       <span class="text-gray-600 font-normal text-lg">Changes can take a moment until they are visible on third party platforms.</span>
     </div>
 
-    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_path(@conn, :update, @network), button_text: "Update Network"}) %>
+    <%= render "form.html", Map.merge(assigns, %{
+      action: Routes.admin_network_path(@conn, :update, @network), 
+      button_text: "Update Network", 
+      cancel_text: "Cancel", 
+      cancel_url: Routes.admin_network_path(@conn, :index)}) %>
 </div>

--- a/lib/radiator_web/templates/admin/network/form.html.eex
+++ b/lib/radiator_web/templates/admin/network/form.html.eex
@@ -12,6 +12,11 @@
       <%= error_tag f, :title %>
     </div>
 
-    <%= submit @button_text, class: "btn btn-blue" %>
+    <div class="flex">
+    <%= submit @button_text, class: "btn" %>
+    <%= if assigns[:cancel_url] do %>
+      <%= link @cancel_text, to: @cancel_url, class: "btn btn-cancel ml-2" %>
+    <% end %>
+    </div>
 <% end %>
 </div>

--- a/lib/radiator_web/templates/admin/network/index.html.eex
+++ b/lib/radiator_web/templates/admin/network/index.html.eex
@@ -7,26 +7,27 @@
     <div class="flex justify-center md:justify-start flex-wrap">
       <%= for network <- @networks do %>
       <div class="w-48 flex flex-col mr-8 mb-10">
-      <a href="<%= Routes.admin_network_podcast_path(@conn, :index, network.id) %>" class="no-underline text-black w-48 bg-white rounded flex flex-col shadow mr-8 mb-8">
-        
-        <div
-          class="w-48 h-48 bg-cover shadow-inner"
-          style="background-image: url(<%= network.image %>)"
-        ></div>
+        <%= link to: Routes.admin_network_podcast_path(@conn, :index, network.id),
+        class: "no-underline text-black w-48 bg-white rounded flex flex-col shadow mr-8 mb-8" do %>
+          
+          <div
+            class="w-48 h-48 bg-cover shadow-inner"
+            style="background-image: url(<%= network.image %>)"
+          ></div>
 
-        <div class="p-3 h-32">
-          <h1 class="text-base mb-1"><%= network.title %></h1>
-        </div>
-      </a> 
-      <%= if has_edit_permission_for_network(@authenticated_user, network) do %>       
-        <%= link to: Routes.admin_network_path(@conn, :edit, network.id), class: "no-underline text-blue-500" do %>
-          <div class="pill">edit</div>
+          <div class="p-3 h-32">
+            <h1 class="text-base mb-1"><%= network.title %></h1>
+          </div>
         <% end %>
+        <%= if has_edit_permission_for_network(@authenticated_user, network) do %>       
+          <%= link to: Routes.admin_network_path(@conn, :edit, network.id), class: "no-underline text-blue-500" do %>
+            <div class="pill">edit</div>
+          <% end %>
+        <% end %>
+        </div>
       <% end %>
-      </div>
-    <% end %>
   
-      <a href="<%= Routes.admin_network_path(@conn, :new) %>" class="w-48 bg-white rounded flex flex-col shadow mr-8 mb-8 no-underline text-black bg-white hover:bg-blue-100">
+      <a href="<%= Routes.admin_network_path(@conn, :new) %>" class="w-48 bg-white rounded flex flex-col shadow mr-8 mb-8 no-underline text-black bg-white hover:bg-highlight">
         
         <div class="w-48 h-48 flex flex-col justify-center items-center">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-12 mb-4 icon-add-circle"><circle cx="12" cy="12" r="10" class="primary"></circle><path class="secondary" d="M13 11h4a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4V7a1 1 0 0 1 2 0v4z"></path></svg>

--- a/lib/radiator_web/templates/admin/network/new.html.eex
+++ b/lib/radiator_web/templates/admin/network/new.html.eex
@@ -4,5 +4,7 @@
       <span class="text-gray-600 font-normal text-lg">Just one form away from your big moment.</span>
     </div>
 
-    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_path(@conn, :create), button_text: "Create Network"}) %>
+    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_path(@conn, :create), button_text: "Create Network", 
+      cancel_text: "Cancel", 
+      cancel_url: Routes.admin_network_path(@conn, :index)}) %>
 </div>

--- a/lib/radiator_web/templates/admin/podcast/edit.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/edit.html.eex
@@ -4,5 +4,7 @@
       <span class="text-gray-600 font-normal text-lg">Changes can take a moment until they are visible on third party platforms.</span>
     </div>
 
-    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_podcast_path(@conn, :update, @podcast.network_id, @podcast), button_text: "Update Podcast"}) %>
+    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_podcast_path(@conn, :update, @podcast.network_id, @podcast), button_text: "Update Podcast",
+    cancel_text: "Cancel",
+    cancel_url: Routes.admin_network_podcast_path(@conn, :show, @podcast.network_id, @podcast)}) %>
 </div>

--- a/lib/radiator_web/templates/admin/podcast/form.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/form.html.eex
@@ -22,12 +22,16 @@
       <%= error_tag f, :description %>
     </div>
 
-    <div class="flex justify-between">
-    <%= submit @button_text, class: "btn btn-blue" %>
+    <div class="flex">
+      <%= submit @button_text, class: "btn" %>
+      <%= if assigns[:cancel_url] do %>
+        <%= link @cancel_text, to: @cancel_url, class: "btn btn-cancel ml-2" %>
+      <% end %>
 
-    <%= if @changeset.data.__meta__.state == :loaded do %>
-      <%= submit "Delete Podcast", class: "btn btn-red", name: "button_action", value: "delete" %>
-    <% end %>
+      <%= if @changeset.data.__meta__.state == :loaded do %>
+        <span class="flex-grow"> </span>
+        <%= submit "Delete Podcast", class: "btn btn-destructive", name: "button_action", value: "delete" %>
+      <% end %>
     </div>
 <% end %>
 </div>

--- a/lib/radiator_web/templates/admin/podcast/index.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/index.html.eex
@@ -33,7 +33,7 @@
 
       <%= if has_manage_permission_for_network(@authenticated_user, @current_network) do %>
 
-      <a href="<%= Routes.admin_network_podcast_path(@conn, :new, @current_network) %>" class="w-48 bg-white rounded flex flex-col shadow mr-8 mb-8 no-underline text-black bg-white hover:bg-blue-100">
+      <a href="<%= Routes.admin_network_podcast_path(@conn, :new, @current_network) %>" class="w-48 bg-white rounded flex flex-col shadow mr-8 mb-8 no-underline text-black bg-white hover:bg-highlight">
         
         <div class="w-48 h-48 flex flex-col justify-center items-center">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-12 mb-4 icon-add-circle"><circle cx="12" cy="12" r="10" class="primary"></circle><path class="secondary" d="M13 11h4a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4V7a1 1 0 0 1 2 0v4z"></path></svg>
@@ -51,7 +51,7 @@
 
       </a>
 
-      <a href="<%= Routes.admin_network_podcast_import_path(@conn, :new, @current_network) %>" class="w-48 bg-white rounded flex flex-col shadow mr-8 mb-8 no-underline text-black bg-white hover:bg-blue-100">
+      <a href="<%= Routes.admin_network_podcast_import_path(@conn, :new, @current_network) %>" class="w-48 bg-white rounded flex flex-col shadow mr-8 mb-8 no-underline text-black bg-white hover:bg-highlight">
         
         <div class="w-48 h-48 flex flex-col justify-center items-center">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-12 mb-4 icon-inbox-download"><path class="primary" d="M8 5H5v10h2a2 2 0 0 1 2 2c0 1.1.9 2 2 2h2a2 2 0 0 0 2-2c0-1.1.9-2 2-2h2V5h-3a1 1 0 0 1 0-2h3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5c0-1.1.9-2 2-2h3a1 1 0 1 1 0 2z"></path><path class="secondary" d="M11 10.59V4a1 1 0 0 1 2 0v6.59l1.3-1.3a1 1 0 0 1 1.4 1.42l-3 3a1 1 0 0 1-1.4 0l-3-3a1 1 0 0 1 1.4-1.42l1.3 1.3z"></path></svg>

--- a/lib/radiator_web/templates/admin/podcast/index.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/index.html.eex
@@ -1,34 +1,34 @@
-<div class="container mx-auto mb-6 px-8">
+<div class="container mb-6 px-8">
     <div class="mb-6">
-      <h1 class="text-3xl font-bold mb-1 text-blue-900">Hi, Happy Podcasting!</h1>
-      <span class="text-gray-600 font-normal text-lg">Let's spark some joy and enlightenment, shall we?</span>
+      <h1 class="text-3xl font-bold mb-1 text-blue-900">Podcasts in <%= @current_network.title %></h1>
     </div>
 
     <div class="flex justify-center md:justify-start flex-wrap">
       <%= for podcast <- @podcasts do %>
-      <a href="<%= Routes.admin_network_podcast_path(@conn, :show, podcast.network_id, podcast) %>" class="no-underline text-black w-48 bg-white rounded flex flex-col shadow mr-8 mb-8">
+        <%= link to: Routes.admin_network_podcast_path(@conn, :show, podcast.network_id, podcast),
+        class: "no-underline text-black w-48 bg-white rounded flex flex-col shadow mr-8 mb-8" do %>
         
-        <div
-          class="w-48 h-48 bg-cover shadow-inner"
-          style="background-image: url(<%= podcast_image_url(podcast) %>)"
-        ></div>
+          <div
+            class="w-48 h-48 bg-cover shadow-inner"
+            style="background-image: url(<%= podcast_image_url(podcast) %>)"
+          ></div>
 
-        <div class="p-3 h-32 overflow-hidden">
-          <h1 class="text-base mb-1"><%= podcast.title %></h1>
-          <p class="text-xs text-gray-600"><%= shorten_string(podcast.subtitle, 140) %></p>
-        </div>
+          <div class="p-3 h-32 overflow-hidden">
+            <h1 class="text-base mb-1"><%= podcast.title %></h1>
+            <p class="text-xs text-gray-600"><%= shorten_string(podcast.subtitle, 140) %></p>
+          </div>
 
-        <div class="flex items-center p-3 border-t border-gray-500 border-solid text-xs text-gray-600">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 mr-3 opacity-75 icon-collection"><rect width="20" height="12" x="2" y="10" class="primary" rx="2"></rect><path class="secondary" d="M20 8H4c0-1.1.9-2 2-2h12a2 2 0 0 1 2 2zm-2-4H6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2z"></path></svg>
-          <span><%= ngettext "One Episode", "%{count} Episodes", podcast.episode_count %></span>
-        </div>
+          <div class="flex items-center p-3 border-t border-gray-500 border-solid text-xs text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 mr-3 opacity-75 icon-collection"><rect width="20" height="12" x="2" y="10" class="primary" rx="2"></rect><path class="secondary" d="M20 8H4c0-1.1.9-2 2-2h12a2 2 0 0 1 2 2zm-2-4H6c0-1.1.9-2 2-2h8a2 2 0 0 1 2 2z"></path></svg>
+            <span><%= ngettext "One Episode", "%{count} Episodes", podcast.episode_count %></span>
+          </div>
 
-        <div class="flex items-center p-3 pt-0 border-gray-500 border-solid text-xs text-gray-600">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 mr-3 opacity-75 icon-trending-up"><path class="primary" d="M3.7 20.7a1 1 0 1 1-1.4-1.4l6-6a1 1 0 0 1 1.4 0l3.3 3.29 4.3-4.3a1 1 0 0 1 1.4 1.42l-5 5a1 1 0 0 1-1.4 0L9 15.4l-5.3 5.3z"></path><path class="secondary" d="M16.59 8l-2.3-2.3A1 1 0 0 1 15 4h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1.7.7L18 9.42l-4.3 4.3a1 1 0 0 1-1.4 0L9 10.4l-5.3 5.3a1 1 0 1 1-1.4-1.42l6-6a1 1 0 0 1 1.4 0l3.3 3.3L16.59 8z"></path></svg>
-          <span>123.456 Downloads</span>
-        </div>
+          <%# <div class="flex items-center p-3 pt-0 border-gray-500 border-solid text-xs text-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 mr-3 opacity-75 icon-trending-up"><path class="primary" d="M3.7 20.7a1 1 0 1 1-1.4-1.4l6-6a1 1 0 0 1 1.4 0l3.3 3.29 4.3-4.3a1 1 0 0 1 1.4 1.42l-5 5a1 1 0 0 1-1.4 0L9 15.4l-5.3 5.3z"></path><path class="secondary" d="M16.59 8l-2.3-2.3A1 1 0 0 1 15 4h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1.7.7L18 9.42l-4.3 4.3a1 1 0 0 1-1.4 0L9 10.4l-5.3 5.3a1 1 0 1 1-1.4-1.42l6-6a1 1 0 0 1 1.4 0l3.3 3.3L16.59 8z"></path></svg>
+            <span>123.456 Downloads</span>
+          </div> %>
 
-      </a>        
+        <% end %>
       <% end %>
 
       <%= if has_manage_permission_for_network(@authenticated_user, @current_network) do %>

--- a/lib/radiator_web/templates/admin/podcast/new.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/new.html.eex
@@ -4,5 +4,7 @@
       <span class="text-gray-600 font-normal text-lg">Just one form away from your big moment.</span>
     </div>
 
-    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_podcast_path(@conn, :create, @current_network), button_text: "Create Podcast"}) %>
+    <%= render "form.html", Map.merge(assigns, %{action: Routes.admin_network_podcast_path(@conn, :create, @current_network), button_text: "Create Podcast",
+        cancel_text: "Cancel",
+    cancel_url: Routes.admin_network_path(@conn, :show,  @current_network)}) %>
 </div>

--- a/lib/radiator_web/templates/admin/podcast/show.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/show.html.eex
@@ -10,7 +10,7 @@
             <%= @podcast.title %>
             <%= if @podcast.published_at && @podcast.slug do %>
             <span class="text-gray-600 font-normal text-lg">
-              <%= link to: Routes.feed_path(@conn, :show, @podcast.slug), class: "no-underline text-blue-500" do %>
+              <%= link to: Routes.feed_path(@conn, :show, @podcast.slug), class: "txt-lnk" do %>
                 RSS Feed
               <% end %>   
             </span>
@@ -34,7 +34,7 @@
       </div>
 
       <div class="flex w-full h-12 justify-end mb-2">
-        <%= link to: Routes.admin_network_podcast_episode_path(@conn, :new, @podcast.network_id, @podcast), class: "btn btn-blue inline-flex items-center" do %>
+        <%= link to: Routes.admin_network_podcast_episode_path(@conn, :new, @podcast.network_id, @podcast), class: "btn inline-flex items-center" do %>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 h-6 mr-2 icon-add"><path fill="white" d="M17 11a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4V7a1 1 0 0 1 2 0v4h4z"></path></svg>
           <span>Create Episode</span>
         <% end %>
@@ -46,7 +46,7 @@
   <h2 class="text-gray-700 mb-2">Drafts</h2>
 
   <%= for episode <- @draft_episodes do %>
-    <%= link to: Routes.admin_network_podcast_episode_path(@conn, :show, @podcast.network_id, @podcast, episode), class: "block no-underline card mb-1 hover:bg-blue-100" do %>
+    <%= link to: Routes.admin_network_podcast_episode_path(@conn, :show, @podcast.network_id, @podcast, episode), class: "block no-underline card mb-1 hover:bg-highlight" do %>
       <div class="flex">
         <%= if episode.image do %>
           <img src="<%= episode_image_url(episode) %>" class="w-24 h-24 mr-6" />
@@ -67,7 +67,7 @@
   <h2 class="text-gray-700 mb-2">Published</h2>
 
   <%= for episode <- @published_episodes do %>
-    <%= link to: Routes.admin_network_podcast_episode_path(@conn, :show, @podcast.network_id, @podcast, episode), class: "block no-underline card mb-1 hover:bg-blue-100" do %>
+    <%= link to: Routes.admin_network_podcast_episode_path(@conn, :show, @podcast.network_id, @podcast, episode), class: "block no-underline card mb-1 hover:bg-highlight" do %>
       <div class="flex">
         <%= if episode.image do %>
           <img src="<%= episode_image_url(episode) %>" class="w-24 h-24 mr-6" />

--- a/lib/radiator_web/templates/admin/podcast/show.html.eex
+++ b/lib/radiator_web/templates/admin/podcast/show.html.eex
@@ -2,48 +2,51 @@
 
   <div class="mb-6 flex w-full justify-between">
     
-    <div class="flex justify-between w-full">
+    <div class="justify-between w-full">
     
-      <div class="w-3/4">
-        <div class="flex">
-          <h1 class="text-3xl font-bold mb-1 text-blue-900 mr-4">
-            <%= @podcast.title %>
-            <%= if @podcast.published_at && @podcast.slug do %>
-            <span class="text-gray-600 font-normal text-lg">
-              <%= link to: Routes.feed_path(@conn, :show, @podcast.slug), class: "txt-lnk" do %>
-                RSS Feed
-              <% end %>   
-            </span>
-            <span class="text-gray-600 font-normal text-lg">
-            |
-            </span>
-            <span class="text-gray-600 font-normal text-lg">
-              <%= link to: Routes.episode_path(@conn, :index, @podcast.slug), class: "no-underline text-blue-500", target: "_blank" do %>
-                Public Page
-              <% end %>   
-            </span>
-            <% end %>
-          </h1>
-          <%= link to: Routes.admin_network_podcast_path(@conn, :edit, @podcast.network_id, @podcast), class: "no-underline text-blue-500" do %>
-          <div class="pill">edit</div>
-          <% end %>      
-        </div>
-        <span class="text-gray-600 font-normal text-lg">
-          <%= @podcast.subtitle %>
-        </span>
-      </div>
-
-      <div class="flex w-full h-12 justify-end mb-2">
-        <%= link to: Routes.admin_network_podcast_episode_path(@conn, :new, @podcast.network_id, @podcast), class: "btn inline-flex items-center" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 h-6 mr-2 icon-add"><path fill="white" d="M17 11a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4V7a1 1 0 0 1 2 0v4h4z"></path></svg>
+      <div class="">
+        <div class="inline h-12 justify-end mb-2 ml-2 float-right">
+      <%= link to: Routes.admin_network_podcast_path(@conn, :edit, @podcast.network_id, @podcast), class: "btn btn-wicon mr-2" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 30 30" class="w-6 h-6 fill-current mr-2"><path d="M4 14a1 1 0 0 1 .3-.7l11-11a1 1 0 0 1 1.4 0l3 3a1 1 0 0 1 0 1.4l-11 11a1 1 0 0 1-.7.3H5a1 1 0 0 1-1-1v-3z"/></svg>
+        <span>Edit</span>
+      <% end %> 
+        <%= link to: Routes.admin_network_podcast_episode_path(@conn, :new, @podcast.network_id, @podcast), class: "btn btn-wicon" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 h-6 mr-2 fill-current"><path d="M17 11a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4V7a1 1 0 0 1 2 0v4h4z"></path></svg>
           <span>Create Episode</span>
         <% end %>
+        </div>
+
+
+        <h1 class="text-3xl font-bold mb-1 mt-2 text-blue-900 mr-4">
+          <%= @podcast.title %>
+        </h1>
+        <p class="text-gray-600 font-normal text-lg mb-2">
+          <%= @podcast.subtitle %>
+        </p>
+        <%= if @podcast.published_at && @podcast.slug do %>
+          <p>
+          <span class="text-gray-600 font-normal text-lg">
+            <%= link "RSS Feed", to: Routes.feed_path(@conn, :show, @podcast.slug), class: "txt-lnk"%>   
+          </span>
+          <span class="text-gray-600 font-normal text-lg">
+          &nbsp;|&nbsp;
+          </span>
+          <span class="text-gray-600 font-normal text-lg">
+            <%= link "Public Page", to: Routes.episode_path(@conn, :index, @podcast.slug), class: "txt-lnk", target: "_blank" %>   
+          </span>
+          </p>
+        <% end %>
+
       </div>
+
+      
 
     </div>
 </div>
 
-  <h2 class="text-gray-700 mb-2">Drafts</h2>
+  <hr class="border-b border-secondary" />
+
+  <h2 class="text-gray-700 text-xl font-bold mb-2">Drafts</h2>
 
   <%= for episode <- @draft_episodes do %>
     <%= link to: Routes.admin_network_podcast_episode_path(@conn, :show, @podcast.network_id, @podcast, episode), class: "block no-underline card mb-1 hover:bg-highlight" do %>
@@ -64,7 +67,9 @@
     <% end %>
   <% end %>
 
-  <h2 class="text-gray-700 mb-2">Published</h2>
+  <hr class="border-b border-secondary" />
+
+  <h2 class="text-gray-700 text-xl font-bold mb-2">Published</h2>
 
   <%= for episode <- @published_episodes do %>
     <%= link to: Routes.admin_network_podcast_episode_path(@conn, :show, @podcast.network_id, @podcast, episode), class: "block no-underline card mb-1 hover:bg-highlight" do %>

--- a/lib/radiator_web/templates/admin/podcast_import/new.html.eex
+++ b/lib/radiator_web/templates/admin/podcast_import/new.html.eex
@@ -14,7 +14,7 @@
             <%= text_input :feed, :feed_url, class: "input", placeholder: "https://www.example.com/feed.xml" %>
           </div>
 
-          <%= submit "Import RSS Feed", class: "btn btn-blue" %>
+          <%= submit "Import RSS Feed", class: "btn" %>
       </form>
     </div>
 

--- a/lib/radiator_web/templates/admin/user_settings/usersettings.html.eex
+++ b/lib/radiator_web/templates/admin/user_settings/usersettings.html.eex
@@ -16,7 +16,7 @@
         <%= password_input f, :password_confirmation, class: "input", placeholder: "" %>
         <%= error_tag f, :password_confirmation%>
       </div>
-      <%= submit "Change Password", class: "btn btn-blue" %>
+      <%= submit "Change Password", class: "btn" %>
   
   <% end %>
   </div>

--- a/lib/radiator_web/templates/layout/app.html.eex
+++ b/lib/radiator_web/templates/layout/app.html.eex
@@ -7,7 +7,7 @@
     <title>Radiator</title>
     <link rel="stylesheet" href="<%= Routes.static_path(@conn, "/css/app.css") %>"/>
   </head>
-  <body class="bg-gray-200 antialiased">
+  <body class="font-sans bg-gray-200 antialiased">
 
     <%= render RadiatorWeb.PageView, "nav.html", assigns %>
 

--- a/lib/radiator_web/templates/layout/public.html.eex
+++ b/lib/radiator_web/templates/layout/public.html.eex
@@ -37,7 +37,7 @@
     }
     </style>
   </head>
-  <body class="bg-purple-100 antialiased">
+  <body class="font-sans bg-purple-100 antialiased">
     <main class="pt-6">
     <%= render @view_module, @view_template, assigns %>
     </main>

--- a/lib/radiator_web/templates/login/login_form.html.eex
+++ b/lib/radiator_web/templates/login/login_form.html.eex
@@ -12,6 +12,6 @@
       <%= error_tag f, :password %>
     </div>
 
-    <%= submit @button_text, class: "btn btn-blue" %>
+    <%= submit @button_text, class: "btn " %>
 <% end %>
 </div>

--- a/lib/radiator_web/templates/login/signup_form.html.eex
+++ b/lib/radiator_web/templates/login/signup_form.html.eex
@@ -21,6 +21,6 @@
       <%= password_input f, :password_repeat, class: "input", placeholder: "" %>
     </div>
 
-    <%= submit @button_text, class: "btn btn-blue" %>
+    <%= submit @button_text, class: "btn" %>
 <% end %>
 </div>

--- a/lib/radiator_web/templates/page/index.html.eex
+++ b/lib/radiator_web/templates/page/index.html.eex
@@ -3,8 +3,8 @@
   <div class="max-w-lg rounded overflow-hidden shadow-lg mb-8 bg-white">
     <div class="px-6 py-6">
       <header class=" mb-8">
-        <h1 class="font-bold text-gray-700 text-2xl mb-1">Welcome to Podlove Radiator</h1>
-        <h2 class="text-xl text-teal-600 tracking-tighter">Podcast hosting for the next century of the internet.</h2>
+        <h1 class="font-bold text-gray-800 text-2xl mb-1">Welcome to Podlove Radiator</h1>
+        <h2 class="text-xl text-secondary">Podcast hosting for the next century of the internet.</h2>
       </header>
 
       <div class="mb-6">
@@ -12,7 +12,7 @@
 
         <ul>
           <li>
-            <a href="/login" class="text-blue-500">Login or Signup</a>
+            <a href="/login" class="no-underline text-primary hover:underline" >Login or Signup</a>
           </li>
         </ul>
       </div>
@@ -22,7 +22,7 @@
 
         <ul>
           <li>
-            <a href="https://github.com/podlove/radiator" class="text-blue-500">podlove/radiator on GitHub</a>
+            <a href="https://github.com/podlove/radiator" class="text-primary hover:underline"><tt>podlove/radiator</tt> on GitHub</a>
           </li>
         </ul>
       </div>

--- a/lib/radiator_web/templates/page/index.html.eex
+++ b/lib/radiator_web/templates/page/index.html.eex
@@ -1,10 +1,10 @@
 <div class="container mx-auto mt-8">
 
-  <div class="max-w-lg rounded overflow-hidden shadow-lg mb-8 bg-white">
+  <div class="max-w-2xl mx-auto rounded overflow-hidden shadow-lg mb-8 bg-white">
     <div class="px-6 py-6">
       <header class=" mb-8">
         <h1 class="font-bold text-gray-800 text-2xl mb-1">Welcome to Podlove Radiator</h1>
-        <h2 class="text-xl text-secondary">Podcast hosting for the next century of the internet.</h2>
+        <h2 class="text-xl text-secondary">Podcast hosting for the next century.</h2>
       </header>
 
       <div class="mb-6">
@@ -22,7 +22,7 @@
 
         <ul>
           <li>
-            <a href="https://github.com/podlove/radiator" class="text-primary hover:underline"><tt>podlove/radiator</tt> on GitHub</a>
+            <a href="https://github.com/podlove/radiator" class="text-primary hover:underline"> <tt>podlove/radiator</tt> on GitHub</a>
           </li>
         </ul>
       </div>

--- a/lib/radiator_web/templates/page/nav.html.eex
+++ b/lib/radiator_web/templates/page/nav.html.eex
@@ -2,9 +2,9 @@
   <div class="w-full bg-secondary h-1"></div>
 </div>
 <div class="flex mb-10 text-white">
-  <div class="w-full bg-primary h-16 flex items-center px-5">
-    <span class="text-2xl font-thin">
-      Radiator 🔥
+  <div class="w-full bg-primary h-16 flex items-center px-4">
+    <span class="text-2xl flex-shrink-0 mr-2">
+      Radiator&nbsp;<svg class="w-10 h-10 inline" viewBox="0 0 900 980" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414"><path d="M944.137 231.69a70.12 70.12 0 0 1 .744 10.094v588.865c0 8.5-.486 16.426-1.408 23.8l-36.79-35.501V266.727l37.454-35.037zm-74.582 551.417l-38.197-36.857V337.194l38.197-35.726v481.639zm-75.464-72.829l-38.188-36.857V407.79l38.188-35.726v338.214zM48.643 231.69l36.78 35.502v552.22L47.98 854.45a70.165 70.165 0 0 1-.743-10.094V255.491c0-8.5.486-16.427 1.407-23.8zm112.107 108.2v409.056l-38.188 35.726v-481.64l38.188 36.857zm75.464 72.829v265.63l-38.188 35.727V375.861l38.188 36.857z" class="primary" fill-rule="nonzero"/><path d="M617.43 47.244H372.497c-50.377 0-91.227 40.85-91.227 91.236v509.526c0 50.386 40.85 91.232 91.227 91.232H617.43c50.39 0 91.232-40.846 91.232-91.232V138.48c0-50.386-40.842-91.236-91.232-91.236" fill="#fff" fill-rule="nonzero"/><path d="M617.43 47.244H372.497c-50.377 0-91.227 40.85-91.227 91.236v509.526c0 50.386 40.85 91.232 91.227 91.232H617.43c50.39 0 91.232-40.846 91.232-91.232V138.48c0-50.386-40.842-91.236-91.232-91.236m0 38.729c28.952 0 52.503 23.555 52.503 52.507v509.526c0 28.952-23.551 52.503-52.503 52.503H372.497c-28.947 0-52.498-23.55-52.498-52.503V138.48c0-28.952 23.551-52.507 52.498-52.507H617.43" fill="#181716" fill-rule="nonzero"/><path d="M494.604 397.575c-76.088 0-137.99 61.906-137.99 137.995 0 76.093 61.902 137.998 137.99 137.998 76.093 0 137.999-61.905 137.999-137.998 0-76.09-61.906-137.995-137.999-137.995m0 38.729c54.831 0 99.27 44.439 99.27 99.266 0 54.822-44.439 99.27-99.27 99.27-54.813 0-99.261-44.448-99.261-99.27 0-54.827 44.448-99.266 99.261-99.266m55.443-319.035c44.938.852 84.893 42.18 82.595 88.008-1.012 20.195-9.63 39.744-23.892 54.457l-115.226 115.29-115.217-115.299c-4.618-4.763-5.81-6.39-8.314-9.88-31.611-44.039-7.436-118.118 50.2-130.666 25.424-5.534 53.14 1.536 73.004 18.766 0 0 29.098-20.354 55.055-20.68.9-.005.895-.005 1.795.004zm-112.554 38.724c-34.22.65-59.668 47.602-31.586 76.562l87.622 87.681 87.617-87.668c25.668-26.482 3.705-84.437-40.863-75.745-12.325 2.402-23.358 10.225-29.907 20.983l-16.843 28.173c-14.076-23.539-28.238-49.65-55.064-49.986-.486-.004-.486 0-.976 0z" fill="#181716" fill-rule="nonzero"/><ellipse cx="73.33" cy="47.329" rx="8.258" ry="8.258" fill="#181716" transform="matrix(-4.30318 0 0 4.30318 810.165 331.905)"/><path fill="none" d="M-.002 0h992.125v897.64H-.002z"/></svg>
     </span>
     <ul class="flex flex-row items-center h-full text-lg font-thin ml-4">
       <%= if Guardian.Plug.current_resource(@conn) do %>
@@ -17,37 +17,42 @@
             <%= link  @current_network.title , to: Routes.admin_network_podcast_path(@conn, :index, @current_network) %>
           </li>
           <%= if assigns[:podcast] do %>
-          <%= render("nav_chevron.html") %>
-          <li class="nav-link">
-            <%= link @podcast.title, to: Routes.admin_network_podcast_path(@conn, :show, @podcast.network_id, @podcast) %>
-          </li>      
+            <%= render("nav_chevron.html") %>
+            <li class="nav-link">
+              <%= link @podcast.title, to: Routes.admin_network_podcast_path(@conn, :show, @podcast.network_id, @podcast) %>
+            </li>      
           <% end %>
           <%= if assigns[:episode] do %>
-          <%= render("nav_chevron.html") %>
-          <li class="nav-link">
-            <%= link @episode.podcast.title, to: Routes.admin_network_podcast_path(@conn, :show, @episode.podcast.network_id, @episode.podcast) %>
-          </li>
-          <%= render("nav_chevron.html") %>
-          <li class="nav-link">
-            <%= link @episode.title, to: Routes.admin_network_podcast_episode_path(@conn, :show, @episode.podcast.network_id, @episode.podcast, @episode) %>
-          </li>
+            <%= render("nav_chevron.html") %>
+            <li class="nav-link truncate-fade">
+              <%= link shorten_string(@episode.podcast.title, 32), to: Routes.admin_network_podcast_path(@conn, :show, @episode.podcast.network_id, @episode.podcast) %>
+            </li>
+            <%= render("nav_chevron.html") %>
+            <li class="nav-link">
+              <%= link @episode.title, to: Routes.admin_network_podcast_episode_path(@conn, :show, @episode.podcast.network_id, @episode.podcast, @episode) %>
+            </li>
           <% end %>        
         <% end %>
       <% end %> 
     </ul>
 
-    <span class="font-thin ml-auto nav-link" style="margin-left:auto">
+    <div class="inline-flex ml-auto items-center ml-3" style="margin-left:auto">
       <%= case Guardian.Plug.current_resource(@conn) do %>
-        <% %Radiator.Auth.User{ name: name } -> %>
-          <li class="nav-link">
-            <%= link "My Profile", to: Routes.admin_user_settings_path(@conn, :index) %>
+        <% %Radiator.Auth.User{ name: name, display_name: display_name } -> %>
+          <li class="nav-link text-center mx-2">
+            <%= link to: Routes.admin_user_settings_path(@conn, :index) do %>
+              <%= content_tag :span, name %>
+              <%= if name != display_name do %>
+                <br /><%= content_tag :span, display_name, class: "text-sm font-thin"  %>
+              <% end %>
+            <% end %>
           </li>
-          <li class="nav-link">
-            <%= link "#{name} (logout)", to: Routes.login_path(@conn, :logout) %>
+          <li class="nav-link pl-2">
+            <%= link "Logout", to: Routes.login_path(@conn, :logout) %>
           </li>
-        <% _ -> %> <%= link "login", to: Routes.login_path(@conn, :login_form) %>
+        <% _ -> %> <%= link "Login", to: Routes.login_path(@conn, :login_form) %>
       <% end %>      
-    </span>
+    </div>
 
   </div>
 </div>

--- a/lib/radiator_web/templates/page/nav.html.eex
+++ b/lib/radiator_web/templates/page/nav.html.eex
@@ -1,8 +1,8 @@
 <div class="flex">
-  <div class="w-full bg-blue-500 h-1"></div>
+  <div class="w-full bg-secondary h-1"></div>
 </div>
 <div class="flex mb-10 text-white">
-  <div class="w-full bg-gray-900 h-16 flex items-center px-5">
+  <div class="w-full bg-primary h-16 flex items-center px-5">
     <span class="text-2xl font-thin">
       Radiator 🔥
     </span>

--- a/lib/radiator_web/templates/page/nav_chevron.html.eex
+++ b/lib/radiator_web/templates/page/nav_chevron.html.eex
@@ -1,4 +1,4 @@
-<li class="nav-chevron">
+<li class="nav-chevron flex-shrink-0">
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-6 icon-chevron-right-circle">
         <path class="primary" d="M10.3 8.7a1 1 0 0 1 1.4-1.4l4 4a1 1 0 0 1 0 1.4l-4 4a1 1 0 0 1-1.4-1.4l3.29-3.3-3.3-3.3z"></path>
     </svg>

--- a/lib/radiator_web/templates/public/episode/index.html.eex
+++ b/lib/radiator_web/templates/public/episode/index.html.eex
@@ -24,7 +24,7 @@
 </div>
 
   <%= for episode <- @episodes do %>
-    <%= link to: episode_public_url(episode, @podcast), class: "block no-underline card mb-1 hover:bg-blue-100" do %>
+    <%= link to: episode_public_url(episode, @podcast), class: "block no-underline card mb-1 hover:bg-highlight" do %>
       <%= render("_episode_entry.html", podcast: @podcast, episode: episode) %>
     <% end %>
   <% end %>

--- a/lib/radiator_web/views/admin/episode_view.ex
+++ b/lib/radiator_web/views/admin/episode_view.ex
@@ -3,35 +3,7 @@ defmodule RadiatorWeb.Admin.EpisodeView do
 
   alias Radiator.Directory.Episode
 
-  def format_bytes(number, precision \\ 2)
-
-  def format_bytes(nil, _) do
-    "? Bytes"
-  end
-
-  def format_bytes(number, _precision) when number < 1_024 do
-    "#{number} Bytes"
-  end
-
-  def format_bytes(number, precision) when number < 1_048_576 do
-    "#{Float.round(number / 1024, precision)} kB"
-  end
-
-  def format_bytes(number, precision) do
-    "#{Float.round(number / 1024 / 1024, precision)} MB"
-  end
-
-  def format_chapter_time(time) do
-    time = round(time / 1_000) * 1_000
-
-    time
-    |> Chapters.Formatters.Normalplaytime.Formatter.format()
-    |> case do
-      "00:" <> rest -> rest
-      sth -> sth
-    end
-    |> String.slice(0..-5)
-  end
+  import RadiatorWeb.FormatHelpers
 
   def episode_image_url(episode) do
     Episode.image_url(episode)

--- a/lib/radiator_web/views/admin/podcast_view.ex
+++ b/lib/radiator_web/views/admin/podcast_view.ex
@@ -1,6 +1,8 @@
 defmodule RadiatorWeb.Admin.PodcastView do
   use RadiatorWeb, :view
 
+  import RadiatorWeb.FormatHelpers
+
   import Radiator.Directory.Editor.Permission, only: [has_permission: 3]
 
   alias Radiator.Directory.{Episode, Podcast}
@@ -15,29 +17,5 @@ defmodule RadiatorWeb.Admin.PodcastView do
 
   def episode_image_url(episode) do
     Episode.image_url(episode)
-  end
-
-  def shorten_string(s, max_length, ellipsis \\ "...")
-  # used for fields that allow for nil (e.g. Podcast.tagline)
-  def shorten_string(nil, _, _) do
-    ""
-  end
-
-  def shorten_string(s, max_length, ellipsis) when is_binary(s) do
-    s
-    |> String.split(" ")
-    |> Enum.reduce_while("", fn x, prev_string ->
-      new_string =
-        case prev_string do
-          "" -> x
-          nonempty_string -> nonempty_string <> " " <> x
-        end
-
-      if String.length(new_string) < max_length do
-        {:cont, new_string}
-      else
-        {:halt, prev_string <> ellipsis}
-      end
-    end)
   end
 end

--- a/lib/radiator_web/views/format_helpers.ex
+++ b/lib/radiator_web/views/format_helpers.ex
@@ -1,0 +1,59 @@
+defmodule RadiatorWeb.FormatHelpers do
+  @moduledoc """
+  General formatting view helpers that should be readily available
+  """
+
+  def format_bytes(number, precision \\ 2)
+
+  def format_bytes(nil, _) do
+    "? Bytes"
+  end
+
+  def format_bytes(number, _precision) when number < 1_024 do
+    "#{number} Bytes"
+  end
+
+  def format_bytes(number, precision) when number < 1_048_576 do
+    "#{Float.round(number / 1024, precision)} kB"
+  end
+
+  def format_bytes(number, precision) do
+    "#{Float.round(number / 1024 / 1024, precision)} MB"
+  end
+
+  def format_chapter_time(time) do
+    time = round(time / 1_000) * 1_000
+
+    time
+    |> Chapters.Formatters.Normalplaytime.Formatter.format()
+    |> case do
+      "00:" <> rest -> rest
+      sth -> sth
+    end
+    |> String.slice(0..-5)
+  end
+
+  def shorten_string(s, max_length, ellipsis \\ "...")
+  # used for fields that allow for nil (e.g. Podcast.tagline)
+  def shorten_string(nil, _, _) do
+    ""
+  end
+
+  def shorten_string(s, max_length, ellipsis) when is_binary(s) do
+    s
+    |> String.split(" ")
+    |> Enum.reduce_while("", fn x, prev_string ->
+      new_string =
+        case prev_string do
+          "" -> x
+          nonempty_string -> nonempty_string <> " " <> x
+        end
+
+      if String.length(new_string) < max_length do
+        {:cont, new_string}
+      else
+        {:halt, prev_string <> ellipsis}
+      end
+    end)
+  end
+end


### PR DESCRIPTION
* fix: network changeset errors weren't displayed
* add: added cancel button to most forms
* add: extracted colors to be primary, secondary, tertiary and highlight for better future flexibility on change
* change: made the titlebar behave better on truncation, highlight again on hover
* change: profile page now accessible on the username, logout is Logout as all our actions are upper case now
* change: took some color hints from the cms, changed font to Avenir Next
* change: added semantic button styles, `btn`, `btn-cancel`, `btn-destructive` and used them accordingly
* moved the more universal used helpers into `RadiatorWeb.FormatHelpers` and importing them in the `RadiatorWeb` `view` function to make them available in all views
