### PR TITLE
fix(api): make REST delete always return 204 if authenticated and params are ok

### DIFF
--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -69,6 +69,8 @@ var data = JSON.stringify({
 });
 ```
 
+`DELETE` methods will always return a `204 No Content` when authenticated and the necessary params were in place.
+
 ## Authentication
 
 To make full use of the API you need to authenticate as an existing user. A successful authentication returns a _token_ that you can use in subsequent requests to authenticate yourself as that user. You do this by setting the token as request header.

--- a/lib/radiator_web.ex
+++ b/lib/radiator_web.ex
@@ -32,6 +32,17 @@ defmodule RadiatorWeb do
     end
   end
 
+  def rest_controller do
+    quote do
+      unquote(do: controller())
+
+      import RadiatorWeb.Helpers.RestApiHelpers
+      use Radiator.Constants
+
+      action_fallback RadiatorWeb.Api.FallbackController
+    end
+  end
+
   def view do
     quote do
       use Phoenix.View,

--- a/lib/radiator_web/controllers/api/audio_controller.ex
+++ b/lib/radiator_web/controllers/api/audio_controller.ex
@@ -51,6 +51,9 @@ defmodule RadiatorWeb.Api.AudioController do
          {:ok, audio} <- Editor.get_audio(user, id),
          {:ok, _} <- Editor.delete_audio(user, audio) do
       send_delete_resp(conn)
+    else
+      @not_found_match -> send_delete_resp(conn)
+      error -> error
     end
   end
 end

--- a/lib/radiator_web/controllers/api/audio_controller.ex
+++ b/lib/radiator_web/controllers/api/audio_controller.ex
@@ -1,10 +1,7 @@
 defmodule RadiatorWeb.Api.AudioController do
-  use RadiatorWeb, :controller
-  use Radiator.Constants
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Directory.Editor
-
-  action_fallback RadiatorWeb.Api.FallbackController
 
   def create(conn, %{"audio" => params = %{"network_id" => network_id}}) do
     with user = current_user(conn),
@@ -53,7 +50,7 @@ defmodule RadiatorWeb.Api.AudioController do
     with user <- current_user(conn),
          {:ok, audio} <- Editor.get_audio(user, id),
          {:ok, _} <- Editor.delete_audio(user, audio) do
-      send_resp(conn, 204, "")
+      send_delete_resp(conn)
     end
   end
 end

--- a/lib/radiator_web/controllers/api/audio_file_controller.ex
+++ b/lib/radiator_web/controllers/api/audio_file_controller.ex
@@ -1,9 +1,7 @@
 defmodule RadiatorWeb.Api.AudioFileController do
-  use RadiatorWeb, :controller
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Media
-
-  action_fallback(RadiatorWeb.Api.FallbackController)
 
   def create(conn, %{"audio_file" => audio_file_params}) do
     with {:ok, audio_file} <- Media.create_audio_file(audio_file_params) do

--- a/lib/radiator_web/controllers/api/authentication_controller.ex
+++ b/lib/radiator_web/controllers/api/authentication_controller.ex
@@ -1,5 +1,5 @@
 defmodule RadiatorWeb.Api.AuthenticationController do
-  use RadiatorWeb, :controller
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Auth
   alias RadiatorWeb.Helpers.AuthHelpers

--- a/lib/radiator_web/controllers/api/collaborator_controller.ex
+++ b/lib/radiator_web/controllers/api/collaborator_controller.ex
@@ -1,12 +1,9 @@
 defmodule RadiatorWeb.Api.CollaboratorController do
-  use RadiatorWeb, :controller
-  use Radiator.Constants, :permissions
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Directory.Editor
   alias Radiator.Directory.Collaborator
   alias Radiator.Auth
-
-  action_fallback RadiatorWeb.Api.FallbackController
 
   def create(conn, %{"username" => username, "permission" => permission} = params) do
     with actor <- current_user(conn),
@@ -65,9 +62,8 @@ defmodule RadiatorWeb.Api.CollaboratorController do
     with actor = current_user(conn),
          {:ok, subject} <- current_subject(actor, params) do
       with {:ok, collaborator} <- Editor.get_collaborator(actor, subject, username),
-           {:ok, collaborator} <- Editor.remove_collaborator(actor, collaborator) do
-        conn
-        |> render("show.json", %{collaborator: collaborator})
+           {:ok, _collaborator} <- Editor.remove_collaborator(actor, collaborator) do
+        send_delete_resp(conn)
       end
     end
   end

--- a/lib/radiator_web/controllers/api/collaborator_controller.ex
+++ b/lib/radiator_web/controllers/api/collaborator_controller.ex
@@ -64,6 +64,9 @@ defmodule RadiatorWeb.Api.CollaboratorController do
       with {:ok, collaborator} <- Editor.get_collaborator(actor, subject, username),
            {:ok, _collaborator} <- Editor.remove_collaborator(actor, collaborator) do
         send_delete_resp(conn)
+      else
+        @not_found_match -> send_delete_resp(conn)
+        error -> error
       end
     end
   end

--- a/lib/radiator_web/controllers/api/episode_controller.ex
+++ b/lib/radiator_web/controllers/api/episode_controller.ex
@@ -33,7 +33,10 @@ defmodule RadiatorWeb.Api.EpisodeController do
     with user <- current_user(conn),
          {:ok, episode} <- Editor.get_episode(user, id),
          {:ok, _} <- Editor.delete_episode(user, episode) do
-          send_delete_resp(conn)
-        end
+      send_delete_resp(conn)
+    else
+      @not_found_match -> send_delete_resp(conn)
+      error -> error
+    end
   end
 end

--- a/lib/radiator_web/controllers/api/episode_controller.ex
+++ b/lib/radiator_web/controllers/api/episode_controller.ex
@@ -1,10 +1,7 @@
 defmodule RadiatorWeb.Api.EpisodeController do
-  use RadiatorWeb, :controller
-  use Radiator.Constants
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Directory.Editor
-
-  action_fallback RadiatorWeb.Api.FallbackController
 
   def create(conn, %{"episode" => params}) do
     with user = current_user(conn),
@@ -36,7 +33,7 @@ defmodule RadiatorWeb.Api.EpisodeController do
     with user <- current_user(conn),
          {:ok, episode} <- Editor.get_episode(user, id),
          {:ok, _} <- Editor.delete_episode(user, episode) do
-      send_resp(conn, 204, "")
-    end
+          send_delete_resp(conn)
+        end
   end
 end

--- a/lib/radiator_web/controllers/api/file_controller.ex
+++ b/lib/radiator_web/controllers/api/file_controller.ex
@@ -1,9 +1,7 @@
 defmodule RadiatorWeb.Api.FileController do
-  use RadiatorWeb, :controller
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Storage
-
-  action_fallback RadiatorWeb.Api.FallbackController
 
   def index(conn, _) do
     {:ok, files} = Storage.list_files()

--- a/lib/radiator_web/controllers/api/network_controller.ex
+++ b/lib/radiator_web/controllers/api/network_controller.ex
@@ -33,6 +33,9 @@ defmodule RadiatorWeb.Api.NetworkController do
          {:ok, network} <- Editor.get_network(user, id),
          {:ok, _} <- Editor.delete_network(user, network) do
       send_delete_resp(conn)
+    else
+      @not_found_match -> send_delete_resp(conn)
+      error -> error
     end
   end
 end

--- a/lib/radiator_web/controllers/api/network_controller.ex
+++ b/lib/radiator_web/controllers/api/network_controller.ex
@@ -1,10 +1,7 @@
 defmodule RadiatorWeb.Api.NetworkController do
-  use RadiatorWeb, :controller
-  use Radiator.Constants
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Directory.Editor
-
-  action_fallback RadiatorWeb.Api.FallbackController
 
   def create(conn, %{"network" => params}) do
     with user = current_user(conn),
@@ -35,7 +32,7 @@ defmodule RadiatorWeb.Api.NetworkController do
     with user <- current_user(conn),
          {:ok, network} <- Editor.get_network(user, id),
          {:ok, _} <- Editor.delete_network(user, network) do
-      send_resp(conn, 204, "")
+      send_delete_resp(conn)
     end
   end
 end

--- a/lib/radiator_web/controllers/api/podcast_controller.ex
+++ b/lib/radiator_web/controllers/api/podcast_controller.ex
@@ -34,6 +34,9 @@ defmodule RadiatorWeb.Api.PodcastController do
          {:ok, podcast} <- Editor.get_podcast(user, id),
          {:ok, _} <- Editor.delete_podcast(user, podcast) do
       send_delete_resp(conn)
+    else
+      @not_found_match -> send_delete_resp(conn)
+      error -> error
     end
   end
 end

--- a/lib/radiator_web/controllers/api/podcast_controller.ex
+++ b/lib/radiator_web/controllers/api/podcast_controller.ex
@@ -1,10 +1,7 @@
 defmodule RadiatorWeb.Api.PodcastController do
-  use RadiatorWeb, :controller
-  use Radiator.Constants
+  use RadiatorWeb, :rest_controller
 
   alias Radiator.Directory.Editor
-
-  action_fallback RadiatorWeb.Api.FallbackController
 
   def create(conn, %{"podcast" => params}) do
     with user = current_user(conn),
@@ -36,7 +33,7 @@ defmodule RadiatorWeb.Api.PodcastController do
     with user <- current_user(conn),
          {:ok, podcast} <- Editor.get_podcast(user, id),
          {:ok, _} <- Editor.delete_podcast(user, podcast) do
-      send_resp(conn, 204, "")
+      send_delete_resp(conn)
     end
   end
 end

--- a/lib/radiator_web/helpers/rest_api_helpers.ex
+++ b/lib/radiator_web/helpers/rest_api_helpers.ex
@@ -1,0 +1,12 @@
+defmodule RadiatorWeb.Helpers.RestApiHelpers do
+  @moduledoc """
+  Authentication helper functions for the web layer.
+  """
+
+  import Plug.Conn, only: [send_resp: 3]
+
+  def send_delete_resp(conn) do
+    conn
+    |> send_resp(204, "")
+  end
+end


### PR DESCRIPTION
add: a line of documentation to clarify this
add: `RestApiHelper` for the consistent response send on delete
add: `rest_controller` as option for the use line to include all things necessary for rest controllers

fixes #150 