### PR TITLE
GraphQL Audio Access

### DIFF
--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -302,6 +302,7 @@ defmodule Radiator.Directory do
     end
   end
 
+  @spec list_audio_files(Audio.t()) :: [AudioFile.t()]
   def list_audio_files(audio = %Audio{}) do
     if is_published(audio) do
       audio

--- a/lib/radiator/directory.ex
+++ b/lib/radiator/directory.ex
@@ -273,6 +273,11 @@ defmodule Radiator.Directory do
   def is_published(%Episode{published_at: date}),
     do: Support.DateTime.before_utc_now?(date)
 
+  # fixme: ensure all entities above are published as well
+  #   applies to all is_published implementations
+  def is_published(%Audio{published_at: date}),
+    do: Support.DateTime.before_utc_now?(date)
+
   def is_published(_), do: false
 
   def get_audio(id) do
@@ -294,6 +299,16 @@ defmodule Radiator.Directory do
     else
       {:get, _} -> {:error, :not_found}
       {:published, _} -> {:error, :unpublished}
+    end
+  end
+
+  def list_audio_files(audio = %Audio{}) do
+    if is_published(audio) do
+      audio
+      |> Ecto.assoc(:audio_files)
+      |> Repo.all()
+    else
+      []
     end
   end
 end

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -437,6 +437,14 @@ defmodule Radiator.Directory.Editor do
     end
   end
 
+  def list_audios(actor = %Auth.User{}, network = %Network{}) do
+    if has_permission(actor, network, :read) do
+      Editor.Manager.list_audios(network)
+    else
+      @not_authorized_match
+    end
+  end
+
   def create_audio(actor = %Auth.User{}, episode = %Episode{}, attrs) do
     if has_permission(actor, episode, :edit) do
       Editor.Manager.create_audio(episode, attrs)

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -438,7 +438,7 @@ defmodule Radiator.Directory.Editor do
   end
 
   def list_audios(actor = %Auth.User{}, network = %Network{}) do
-    if has_permission(actor, network, :read) do
+    if has_permission(actor, network, :readonly) do
       Editor.Manager.list_audios(network)
     else
       @not_authorized_match

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -301,6 +301,15 @@ defmodule Radiator.Directory.Editor do
     |> Repo.all()
   end
 
+  @doc """
+  List episodes for audio that given user can see.
+  """
+  def list_episodes(actor = %Auth.User{}, audio = %Audio{}) do
+    from(e in Episode, where: e.audio_id == ^audio.id)
+    |> Repo.all()
+    |> Enum.filter(fn episode -> has_permission(actor, episode, :readonly) end)
+  end
+
   def create_episode(actor = %Auth.User{}, podcast = %Podcast{}, attrs) do
     if has_permission(actor, podcast, :manage) do
       Editor.Manager.create_episode(podcast, attrs)

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -305,9 +305,24 @@ defmodule Radiator.Directory.Editor do
   List episodes for audio that given user can see.
   """
   def list_episodes(actor = %Auth.User{}, audio = %Audio{}) do
-    from(e in Episode, where: e.audio_id == ^audio.id)
-    |> Repo.all()
-    |> Enum.filter(fn episode -> has_permission(actor, episode, :readonly) end)
+    if has_permission(actor, audio, :readonly) do
+      audio
+      |> Ecto.assoc(:episodes)
+      |> Repo.all()
+      |> Enum.filter(fn episode -> has_permission(actor, episode, :readonly) end)
+    else
+      @not_authorized_match
+    end
+  end
+
+  def list_audio_files(actor = %Auth.User{}, audio = %Audio{}) do
+    if has_permission(actor, audio, :readonly) do
+      audio
+      |> Ecto.assoc(:audio_files)
+      |> Repo.all()
+    else
+      @not_authorized_match
+    end
   end
 
   def create_episode(actor = %Auth.User{}, podcast = %Podcast{}, attrs) do

--- a/lib/radiator/directory/editor/manager.ex
+++ b/lib/radiator/directory/editor/manager.ex
@@ -55,6 +55,13 @@ defmodule Radiator.Directory.Editor.Manager do
     end
   end
 
+  def list_audios(network = %Network{}) do
+    network
+    |> Ecto.assoc(:audios)
+    |> Repo.all()
+    |> (&{:ok, &1}).()
+  end
+
   # todo: this raises if used on an episode that already has an associated audio.
   #       we need to define a way, maybe even a separate API,
   #       to remove or replace an episode audio.

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -294,10 +294,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     {:ok, episode.audio}
   end
 
-  def get_enclosure(%Episode{} = episode, _args, %{context: %{current_user: _user}}) do
-    {:ok, Episode.enclosure(episode)}
-  end
-
   def get_chapters(%Audio{} = audio, _, _) do
     chapter_query = Radiator.AudioMeta.Chapter.ordered_query()
     audio = Radiator.Repo.preload(audio, chapters: chapter_query)

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -298,6 +298,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     {:ok, Editor.list_audio_files(user, audio)}
   end
 
+  def get_audio_files(audio = %Audio{}, _args, _resolution) do
+    {:ok, Radiator.Directory.list_audio_files(audio)}
+  end
+
   def list_audios(%Network{} = network, _args, %{context: %{current_user: actor}}) do
     Editor.list_audios(actor, network)
   end

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -221,6 +221,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     end
   end
 
+  def get_episodes(audio = %Audio{}, _, %{context: %{current_user: user}}) do
+    {:ok, Editor.list_episodes(user, audio)}
+  end
+
   def create_episode(_parent, %{podcast_id: podcast_id, episode: args}, %{
         context: %{current_user: user}
       }) do
@@ -296,6 +300,12 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
 
   def find_audio(%Episode{} = episode, _args, %{context: %{current_user: _user}}) do
     {:ok, episode.audio}
+  end
+
+  def find_audio(_parent, %{id: id}, %{context: %{current_user: user}}) do
+    with_audio user, id do
+      fn audio -> {:ok, audio} end
+    end
   end
 
   def get_chapters(%Audio{} = audio, _, _) do

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -294,6 +294,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     end
   end
 
+  def get_audio_files(audio = %Audio{}, _args, %{context: %{current_user: user}}) do
+    {:ok, Editor.list_audio_files(user, audio)}
+  end
+
   def list_audios(%Network{} = network, _args, %{context: %{current_user: actor}}) do
     Editor.list_audios(actor, network)
   end

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -290,6 +290,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     end
   end
 
+  def list_audios(%Network{} = network, _args, %{context: %{current_user: actor}}) do
+    Editor.list_audios(actor, network)
+  end
+
   def find_audio(%Episode{} = episode, _args, %{context: %{current_user: _user}}) do
     {:ok, episode.audio}
   end

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -60,6 +60,11 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
       resolve &Resolvers.Editor.list_podcasts/3
     end
 
+    field :audios, list_of(:audio) do
+      description "Audios attached directly to the network."
+      resolve &Resolvers.Editor.list_audios/3
+    end
+
     field :collaborators, list_of(:collaborator) do
       resolve &Resolvers.Editor.list_collaborators/3
     end

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -151,10 +151,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
       resolve &Resolvers.Editor.find_podcast/3
     end
 
-    field :enclosure, :enclosure do
-      resolve &Resolvers.Editor.get_enclosure/3
-    end
-
     field :audio, :audio do
       resolve &Resolvers.Editor.find_audio/3
     end

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -178,6 +178,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
     field :episodes, list_of(:episode) do
       resolve &Resolvers.Editor.get_episodes/3
     end
+
+    field :audio_files, list_of(:audio_file) do
+      resolve &Resolvers.Editor.get_audio_files/3
+    end
   end
 
   @desc "The input for an episode in a podcast"

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -174,6 +174,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
       # resolve dataloader(Radiator.AudioMeta, :chapters)
       resolve &Resolvers.Editor.get_chapters/3
     end
+
+    field :episodes, list_of(:episode) do
+      resolve &Resolvers.Editor.get_episodes/3
+    end
   end
 
   @desc "The input for an episode in a podcast"

--- a/lib/radiator_web/graphql/common/types.ex
+++ b/lib/radiator_web/graphql/common/types.ex
@@ -19,13 +19,6 @@ defmodule RadiatorWeb.GraphQL.Common.Types do
     field :title, :string
   end
 
-  @desc "An audio enclosure"
-  object :enclosure do
-    field :url, :string
-    field :type, :string
-    field :length, :integer
-  end
-
   @desc "A user API session"
   object :session do
     field :username, :string

--- a/lib/radiator_web/graphql/public/resolvers/directory.ex
+++ b/lib/radiator_web/graphql/public/resolvers/directory.ex
@@ -51,10 +51,6 @@ defmodule RadiatorWeb.GraphQL.Public.Resolvers.Directory do
     {:ok, episode.audio}
   end
 
-  def get_enclosure(%Episode{} = episode, _args, _resolution) do
-    {:ok, Episode.enclosure(episode)}
-  end
-
   def get_image_url(episode = %Episode{}, _, _) do
     {:ok, Media.EpisodeImage.url({episode.image, episode})}
   end

--- a/lib/radiator_web/graphql/public/types.ex
+++ b/lib/radiator_web/graphql/public/types.ex
@@ -77,10 +77,6 @@ defmodule RadiatorWeb.GraphQL.Public.Types do
       resolve &Resolvers.Directory.find_podcast/3
     end
 
-    field :enclosure, :enclosure do
-      resolve &Resolvers.Directory.get_enclosure/3
-    end
-
     field :audio, :audio do
       resolve &Resolvers.Directory.find_audio/3
     end

--- a/lib/radiator_web/graphql/schema.ex
+++ b/lib/radiator_web/graphql/schema.ex
@@ -150,6 +150,14 @@ defmodule RadiatorWeb.GraphQL.Schema do
       middleware Middleware.RequireAuthentication
       resolve &Admin.Resolvers.Editor.list_networks/3
     end
+
+    @desc "Get one audio"
+    field :audio, :audio do
+      arg :id, non_null(:id)
+
+      middleware Middleware.RequireAuthentication
+      resolve &Admin.Resolvers.Editor.find_audio/3
+    end
   end
 
   mutation do

--- a/lib/radiator_web/views/api/podcast_view.ex
+++ b/lib/radiator_web/views/api/podcast_view.ex
@@ -5,10 +5,10 @@ defmodule RadiatorWeb.Api.PodcastView do
 
   def render("index.json", assigns = %{podcasts: podcasts}) do
     %Document{}
-    |> Document.add_link(%Link{
-      rel: "self",
-      href: Routes.api_podcast_path(assigns.conn, :index)
-    })
+    # |> Document.add_link(%Link{
+    #   rel: "self",
+    #   href: Routes.api_podcast_path(assigns.conn, :index)
+    # })
     |> Document.add_embed(%Embed{
       resource: "rad:podcast",
       embed: render_many(podcasts, PodcastView, "podcast.json", assigns)

--- a/test/radiator_web/graphql/admin/schema/query/episodes_test.exs
+++ b/test/radiator_web/graphql/admin/schema/query/episodes_test.exs
@@ -3,7 +3,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
 
   import Radiator.Factory
 
-  alias Radiator.Directory.Episode
   alias Radiator.Media
 
   @doc """
@@ -25,11 +24,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
     episode(id: $id) {
       id
       title
-      enclosure {
-        length
-        type
-        url
-      }
       audio {
         chapters {
           image
@@ -68,8 +62,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
         audio: audio
       )
 
-    enclosure = Episode.enclosure(episode)
-
     conn = get conn, "/api/graphql", query: @single_query, variables: %{"id" => episode.id}
 
     assert json_response(conn, 200) == %{
@@ -77,11 +69,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
                "episode" => %{
                  "id" => Integer.to_string(episode.id),
                  "title" => episode.title,
-                 "enclosure" => %{
-                   "length" => enclosure.length,
-                   "type" => enclosure.type,
-                   "url" => enclosure.url
-                 },
                  "audio" => %{
                    "chapters" => [
                      %{

--- a/test/radiator_web/graphql/public/schema/query/episodes_test.exs
+++ b/test/radiator_web/graphql/public/schema/query/episodes_test.exs
@@ -2,7 +2,6 @@ defmodule RadiatorWeb.GraphQL.Public.Schema.Query.EpisodesTest do
   use RadiatorWeb.ConnCase, async: true
   import Radiator.Factory
 
-  alias Radiator.Directory.Episode
   alias Radiator.Media
 
   @single_query """
@@ -10,11 +9,6 @@ defmodule RadiatorWeb.GraphQL.Public.Schema.Query.EpisodesTest do
     publishedEpisode(id: $id) {
       id
       title
-      enclosure {
-        length
-        type
-        url
-      }
       audio {
         chapters {
           image
@@ -53,8 +47,6 @@ defmodule RadiatorWeb.GraphQL.Public.Schema.Query.EpisodesTest do
         audio: audio
       )
 
-    enclosure = Episode.enclosure(episode)
-
     conn = get conn, "/api/graphql", query: @single_query, variables: %{"id" => episode.id}
 
     assert image_url =~ "http"
@@ -64,11 +56,6 @@ defmodule RadiatorWeb.GraphQL.Public.Schema.Query.EpisodesTest do
                "publishedEpisode" => %{
                  "id" => Integer.to_string(episode.id),
                  "title" => episode.title,
-                 "enclosure" => %{
-                   "length" => enclosure.length,
-                   "type" => enclosure.type,
-                   "url" => enclosure.url
-                 },
                  "audio" => %{
                    "chapters" => [
                      %{


### PR DESCRIPTION
- removes deprecated `enclosure` from API
- list audios for network
- list episodes for an audio
- list audio files for an audio

Not everything is implemented in public + cms API. For example I don't think it's necessary to access all network-audios publicly.

closes #158 