### PR TITLE
feature(content, api): align episode api with documentation, provide rest api for image and summary fields

### DIFF
--- a/guides/data_and_structure.md
+++ b/guides/data_and_structure.md
@@ -27,11 +27,11 @@ Potential fields open for discussion:
 
 ### Podcast
 
-A **Podcast** belongs to exactly a **Network**
+A **Podcast** belongs to exactly one **Network**
 
  Field | Type | Description 
    --: | :--  | :--
-`shortID` | `String` | Short basis to identify a podcast in an URL, hashtag, etc. Also for easy referring to episodes. E.g. `FS` for freakshow, so an episode becomes `FS130`. Typically between 2 and 5 letters, and has to be unique inside a network as it is used for URL slugs as well.
+`shortId` | `String` | Short basis to identify a podcast in an URL, hashtag, etc. Also for easy referring to episodes. E.g. `FS` for freakshow, so an episode becomes `FS130`. Typically between 2 and 5 letters, and has to be unique inside a network as it is used for URL slugs as well.
  `title` | `String` | The name of the podcast
  `image` | `Image`  | An cover image for the podcast
  `subtitle` | `String` | The subtitle line. Is put in `description` and `itunes:subtitle` in the feed. Usually used as one line description display in podcast directories. Currently doesn't appear in iTunes anywhere prominently.
@@ -56,21 +56,22 @@ Existing fields, worthy of discussion:
 
 ### Episode 
 
-A **Episode** belongs to exactly a **Podcast**
+A **Episode** belongs to exactly one **Podcast**
 
  Field | Type | Description 
  ----: | :--  | :--
-`shortID` | `String` | Full short ID of the episode. Defaults to `<shortIDOfPodcast><episodenumberWithLeadingZeros>`, e.g. `FS002`.
+ `guid` | `String` | Globally Unique ID of the episode. Will be prefilled on publish if omitted
+`shortId` | `String` | Full short ID of the episode. Defaults to `<shortIDOfPodcast><episodenumberWithLeadingZeros>`, e.g. `FS002`.
  `title` | `String` | The name of the episode. Will be put into `title`, and `itunes:title`. If prefixed with the short ID, the shortID and following whitespace will be stripped for the `itunes:title` to conform with Apple's guidelines there
  `image` | `Image`  | A cover image for the episode. Optional, if none the one of the podcast will be used.
  `subtitle` | `String` | The subtitle line. Is put in `itunes:subtitle` in the feed. Usually used as one line description display tabular listings (e.g. in the iTunes episode table).
  `summary` | `Text` | Long form description of the episode. Also known as show notes. Is put in `description` in the feed. No HTML or Links allowed, or if present will not be preserved or shown appropriately by clients. Optional, if clear will be filled by the stripped version of `summaryHtml` if that is present.
- `summaryHTML` | `Text` | Long form description of the episode. Also known as show notes. Is put in `content:encoded` in the feed. Clients that are capable will use this, and at least show links, sometimes more. Optional.
+ `summaryHtml` | `Text` | Long form description of the episode. Also known as show notes. Is put in `content:encoded` in the feed. Clients that are capable will use this, and at least show links, sometimes more. Optional.
  `summarySource` | `Text` | Potential source for the summary fields, e.g. can be used by frontends to store and support any form of structured data they use to edit the fields. Optional
- `guid` | `String` | Globally Unique ID of the episode.
  `slug` | `String` | short name that usually looks good in the title of an URL. Defaults to the shortID but can be customized.
- `publishedAt` | `DateTime` | Time of publishing. Currently also used to determine if the  episode has been published and is public.
- `number` | `Integer` | "Track" number of the episode in the podcast. aka `episodeNumber`
+ `publishedAt` | `DateTime` | Time of publishing. Currently also used to determine if the episode has been published and is public.
+
+ `number` | `Integer` | "Track" number of the episode in the podcast. aka `episodeNumber` will be put in `itunes:episode` in the feed, and used to generate `shortId` and `guid`
  
 Potential fields open for discussion:  
 
@@ -82,7 +83,7 @@ Potential fields open for discussion:
 
 ### Audio
 
-An **Audio** belongs to at least a **Network** or **Episode** but can be used in multiple locations.
+An **Audio** belongs to at least one **Network** or one **Episode** but can be used in multiple locations.
 
  Field | Type | Description 
    --: | :--  | :--
@@ -98,7 +99,7 @@ Important fields currently missing:
 
 ### AudioFile
 
-An **AudioFile** belongs to an **Audio**
+An **AudioFile** belongs to one **Audio**
 
  Field | Type | Description 
    --: | :--  | :--
@@ -108,7 +109,7 @@ An **AudioFile** belongs to an **Audio**
  
 ### Chapter
 
-An **Chapter** belongs to an **Audio**
+An **Chapter** belongs to one **Audio**
 
  Field | Type | Description 
    --: | :--  | :--
@@ -119,7 +120,7 @@ An **Chapter** belongs to an **Audio**
 
 ### Person
 
-A **Person** belongs to a network. It can take part in contributions.
+A **Person** belongs to one network. It can take part in contributions.
 
 Field | Type | Description 
   --: | :--  | :--
@@ -132,7 +133,7 @@ Field | Type | Description
 
 ### Contribution
 
-A **Contribution** references a Person and either an **Audio** or a **Podcast**
+A **Contribution** references a Person and either one **Audio** or one **Podcast**
 
  Field | Type | Description 
    --: | :--  | :--

--- a/guides/graphql_api.md
+++ b/guides/graphql_api.md
@@ -13,8 +13,10 @@ schema {
 
 """An audio object"""
 type Audio {
+  audioFiles: [AudioFile]
   chapters(order: SortOrder = ASC): [Chapter]
   duration: String
+  episodes: [Episode]
   id: ID!
   publishedAt: DateTime
   title: String
@@ -50,20 +52,12 @@ be converted to UTC and any UTC offset other than 0 will be rejected.
 """
 scalar DateTime
 
-"""An audio enclosure"""
-type Enclosure {
-  length: Int
-  type: String
-  url: String
-}
-
 """An episode in a podcast"""
 type Episode {
   audio: Audio
   content: String
   description: String
   duration: String
-  enclosure: Enclosure
   guid: String
   id: ID!
   image: String
@@ -103,6 +97,8 @@ type FeedInfo {
 
 """A network"""
 type Network {
+  """Audios attached directly to the network."""
+  audios: [Audio]
   collaborators: [Collaborator]
   id: ID!
   image: String
@@ -211,7 +207,6 @@ type PublishedEpisode {
   content: String
   description: String
   duration: String
-  enclosure: Enclosure
   guid: String
   id: ID!
   image: String
@@ -312,6 +307,9 @@ type RootMutationType {
 }
 
 type RootQueryType {
+  """Get one audio"""
+  audio(id: ID!): Audio
+
   """Get one episode"""
   episode(id: ID!): Episode
 

--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -263,14 +263,18 @@ DELETE /api/rest/v1/podcasts/:id/collaborators/:username
 
 ### Parameters for Create & Update
 
-| Name                   | Type      | Description   |
-| ---------------------- | --------- | ------------- |
-| `episode[title]`       | `string`  | **Required.** |
-| `episode[podcast_id]`  | `integer` | **Required.** |
-| `episode[subtitle]`    | `string`  |               |
-| `episode[description]` | `string`  |               |
-| `episode[number]`      | `integer` |               |
-| `episode[short_id]`    | `string`  |               |
+| Name                      | Type      | Description                                                             |
+| ------------------------- | --------- | ----------------------------------------------------------------------- |
+| `episode[title]`          | `string`  | **Required.**                                                           |
+| `episode[podcast_id]`     | `integer` | **Required.**                                                           |
+| `episode[short_id]`       | `string`  | Full combined short id, usually short_id + Number                       |
+| `episode[guid]`           | `string`  | guid, prefilled on publish if unspecified                               |
+| `episode[subtitle]`       | `string`  | One line description of the episode                                     |
+| `episode[summary]`        | `text`    | Multiline description, plain text only                                  |
+| `episode[summary_html]`   | `text`    | Multiline description, html. Will be put in `content:encoded` in a feed |
+| `episode[summary_source]` | `text`    | Multiline description, arbritary format chosen by frontends.            |
+| `episode[image]`          | `Image`   | Cover Image                                                             |
+| `episode[number]`         | `integer` | Episode "Track" number, will be put in `itunes:episode` in the feed     |
 
 ### Create
 

--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -272,7 +272,7 @@ DELETE /api/rest/v1/podcasts/:id/collaborators/:username
 | `episode[subtitle]`       | `string`  | One line description of the episode                                     |
 | `episode[summary]`        | `text`    | Multiline description, plain text only                                  |
 | `episode[summary_html]`   | `text`    | Multiline description, html. Will be put in `content:encoded` in a feed |
-| `episode[summary_source]` | `text`    | Multiline description, arbritary format chosen by frontends.            |
+| `episode[summary_source]` | `text`    | Multiline description, arbitrary format chosen by frontends.            |
 | `episode[image]`          | `Image`   | Cover Image                                                             |
 | `episode[number]`         | `integer` | Episode "Track" number, will be put in `itunes:episode` in the feed     |
 

--- a/lib/radiator/directory/episode.ex
+++ b/lib/radiator/directory/episode.ex
@@ -13,16 +13,20 @@ defmodule Radiator.Directory.Episode do
   alias Radiator.Media.AudioFileUpload
 
   schema "episodes" do
-    field :content, :string
-    field :description, :string
     field :guid, :string
+    field :short_id, :string
+
+    field :title, :string
+    field :subtitle, :string
+    field :summary, :string
+    field :summary_html, :string
+    field :summary_source, :string
     field :image, Media.EpisodeImage.Type
+
     field :number, :integer
     field :published_at, :utc_datetime
-    field :subtitle, :string
-    field :title, :string
+
     field :slug, TitleSlug.Type
-    field :short_id, :string
 
     # use enclosure form field to upload audio file
     field :enclosure, :map, virtual: true
@@ -41,8 +45,9 @@ defmodule Radiator.Directory.Episode do
     |> cast(attrs, [
       :title,
       :subtitle,
-      :description,
-      :content,
+      :summary,
+      :summary_html,
+      :summary_source,
       :guid,
       :number,
       :published_at,

--- a/lib/radiator/directory/importer.ex
+++ b/lib/radiator/directory/importer.ex
@@ -100,9 +100,9 @@ defmodule Radiator.Directory.Importer do
           Editor.Manager.create_episode(podcast, %{
             guid: episode.guid,
             title: episode.title,
-            subtitle: episode.subtitle,
-            description: episode.description,
-            content: episode.content_encoded,
+            subtitle: episode.subtitle || episode.description,
+            summary: episode.summary || episode.description,
+            summary_html: episode.content_encoded,
             published_at: episode.pub_date,
             number: episode.episode
           })

--- a/lib/radiator/feed/episode_builder.ex
+++ b/lib/radiator/feed/episode_builder.ex
@@ -16,37 +16,38 @@ defmodule Radiator.Feed.EpisodeBuilder do
 
   def fields(_, episode) do
     []
+    |> add(guid(episode))
     |> add(element(:title, episode.title))
     |> add(element(:link, Episode.public_url(episode)))
     |> add(subtitle(episode))
-    |> add(publication_date(episode))
-    |> add(summary(episode))
     |> add(description(episode))
+    |> add(summary(episode))
+    |> add(publication_date(episode))
     |> add(enclosure(episode))
     |> add(contributors(episode))
-    |> add(guid(episode))
     |> add(chapters(episode))
     |> add(content(episode))
     |> Enum.reverse()
   end
 
+  # Both subtitle and description are derived from the subtitle property intentionally
   defp subtitle(%Episode{subtitle: subtitle}) when set?(subtitle),
     do: element("itunes:subtitle", subtitle)
 
   defp subtitle(_), do: nil
 
-  defp summary(%Episode{description: description}) when set?(description),
-    do: element("itunes:summary", description)
-
-  defp summary(_), do: nil
-
-  defp description(%Episode{description: description}) when set?(description),
+  defp description(%Episode{subtitle: description}) when set?(description),
     do: element(:description, description)
 
   defp description(_), do: nil
 
-  defp content(%Episode{content: content}) when set?(content),
-    do: element("content:encoded", {:cdata, content})
+  defp summary(%Episode{summary: summary}) when set?(summary),
+    do: element("itunes:summary", summary)
+
+  defp summary(_), do: nil
+
+  defp content(%Episode{summary_html: summary_html}) when set?(summary_html),
+    do: element("content:encoded", {:cdata, summary_html})
 
   defp content(_), do: nil
 

--- a/lib/radiator_web/controllers/player_controller.ex
+++ b/lib/radiator_web/controllers/player_controller.ex
@@ -32,7 +32,7 @@ defmodule RadiatorWeb.PlayerController do
     |> Map.merge(%{
       title: episode.title,
       subtitle: episode.subtitle,
-      summary: episode.description,
+      summary: episode.summary_html || episode.summary,
       poster: Episode.image_url(episode, %{podcast: podcast}),
       link: Episode.public_url(episode, podcast),
       publicationDate: DateTime.to_iso8601(episode.published_at),

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -130,14 +130,19 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
   @desc "An episode in a podcast"
   object :episode do
     field :id, non_null(:id)
-    field :content, :string
-    field :description, :string
+
+    field :guid, :string
+    field :short_id, :string
+    field :title, :string
+    field :subtitle, :string
+
+    field :summary, :string
+    field :summary_html, :string
+    field :summary_source, :string
 
     field :duration, :string do
       resolve &Resolvers.Editor.get_duration/3
     end
-
-    field :guid, :string
 
     field :image, :string do
       resolve &Resolvers.Editor.get_image_url/3

--- a/lib/radiator_web/graphql/public/types.ex
+++ b/lib/radiator_web/graphql/public/types.ex
@@ -58,21 +58,27 @@ defmodule RadiatorWeb.GraphQL.Public.Types do
   @desc "A published episode in a podcast"
   object :published_episode do
     field :id, non_null(:id)
-    field :content, :string
-    field :description, :string
-    field :duration, :string
     field :guid, :string
+    field :short_id, :string
+    field :title, :string
+    field :subtitle, :string
+
+    field :summary, :string
+    field :summary_html, :string
+    field :summary_source, :string
+
+    field :duration, :string do
+      resolve &RadiatorWeb.GraphQL.Admin.Resolvers.Editor.get_duration/3
+    end
 
     field :image, :string do
       resolve &Resolvers.Directory.get_image_url/3
     end
 
     field :number, :integer
+
     field :published_at, :datetime
-    field :subtitle, :string
-    field :title, :string
     field :slug, :string
-    field :short_id, :string
 
     field :podcast, :published_podcast do
       resolve &Resolvers.Directory.find_podcast/3

--- a/lib/radiator_web/templates/admin/episode/form.html.eex
+++ b/lib/radiator_web/templates/admin/episode/form.html.eex
@@ -17,9 +17,9 @@
       <%= error_tag f, :subtitle %>
     </div>
     <div class="mb-6">
-      <%= label f, :description, class: "font-bold text-sm text-gray-700 uppercase tracking-wider mb-2 block" %>
-      <%= textarea f, :description, rows: 3, class: "input", placeholder: "One-liner to grab the listener's attention" %>
-      <%= error_tag f, :description %>
+      <%= label f, :summary, class: "font-bold text-sm text-gray-700 uppercase tracking-wider mb-2 block" %>
+      <%= textarea f, :summary, rows: 3, class: "input", placeholder: "Multiline description aka 'show notes'" %>
+      <%= error_tag f, :summary %>
     </div>
 
     <div class="mb-6">

--- a/lib/radiator_web/templates/admin/episode/show.html.eex
+++ b/lib/radiator_web/templates/admin/episode/show.html.eex
@@ -13,7 +13,7 @@
         <%= @episode.subtitle %>
       </div>
       <div class="max-w-md text-black font-normal">
-        <%= raw @episode.description %>
+        <%= raw @episode.summary %>
       </div>
     </div>
     <div>

--- a/lib/radiator_web/templates/public/episode/_episode_entry.html.eex
+++ b/lib/radiator_web/templates/public/episode/_episode_entry.html.eex
@@ -2,10 +2,11 @@
 <img src="<%= episode_image_url(@episode, @podcast) %>" class="w-24 h-24 mr-6" />
 <div>
 <%= if @episode.number do %>
-<div class="text-gray-700 text-sm uppercase tracking-wider mb-2">Episode <%= @episode.number %></div>
+<div class="text-gray-700 text-sm uppercase tracking-wider float-right">Episode <%= @episode.number %></div>
 <% end %>
-<div class="font-bold text-black"><%= @episode.title %></div>
-<div class="text-gray-700 text-sm mb-2"><%= @episode.subtitle %></div>
+<div class="font-bold text-black mb-2"><%= @episode.title %></div>
+<div class="text-gray-700 mb-2"><%= @episode.subtitle %></div>
+<div class="text-gray-700 text-sm mb-2"><%= @episode.summary %></div>
 <p class="text-gray-900 text-xs"><%= format_date(@episode.published_at) %> - <%= @episode.audio.duration %></p> 
 </div>
 </div>

--- a/lib/radiator_web/templates/public/episode/index.html.eex
+++ b/lib/radiator_web/templates/public/episode/index.html.eex
@@ -4,20 +4,27 @@
     
     <div class="flex justify-between w-full">
     
-      <div class="w-3/4">
+      <div class="w-full">
+            <p class="text-gray-600 font-normal text-lg float-right">
+              <%= link to: Routes.feed_path(@conn, :show, @podcast.slug), class: "no-underline text-blue-500" do %>
+                RSS Feed
+              <% end %>   
+            </p>
         <div class="flex">
           <h1 class="text-3xl font-bold mb-1 text-blue-900 mr-4">
             <%= @podcast.title %>
             <span class="text-gray-600 font-normal text-lg">
-              <%= link to: Routes.feed_path(@conn, :show, @podcast.slug), class: "no-underline text-blue-500" do %>
-                RSS Feed
-              <% end %>   
-            </span>
+          <%= @podcast.author %>
+        </span>
           </h1>
         </div>
-        <span class="text-gray-600 font-normal text-lg">
+        
+        <p class="text-gray-600 font-normal text-lg">
           <%= @podcast.subtitle %>
-        </span>
+        </p>
+        <p class="text-gray-600 font-normal text-sm w-3/4">
+          <%= @podcast.summary %>
+        </p>
       </div>
 
     </div>

--- a/lib/radiator_web/templates/public/episode/show.html.eex
+++ b/lib/radiator_web/templates/public/episode/show.html.eex
@@ -16,7 +16,7 @@
   </div>
     <div class="w-full mb-4">
       <div class="text-black font-normal episode-description">
-        <%= raw @episode.description %>
+        <%= @episode.summary %>
       </div>
     </div>
 
@@ -30,5 +30,5 @@
 
 </div>
 <div class="container mx-auto mb-6 px-8 content-encoded">
-<%= raw(@episode.content) %>
+<%= raw(@episode.summary_html) %>
 </div>

--- a/lib/radiator_web/views/admin/episode_view.ex
+++ b/lib/radiator_web/views/admin/episode_view.ex
@@ -1,15 +1,6 @@
 defmodule RadiatorWeb.Admin.EpisodeView do
   use RadiatorWeb, :view
 
-  alias Radiator.Directory.Episode
-
   import RadiatorWeb.FormatHelpers
-
-  def episode_image_url(episode) do
-    Episode.image_url(episode)
-  end
-
-  def chapter_image_url(chapter) do
-    Radiator.AudioMeta.Chapter.image_url(chapter)
-  end
+  import RadiatorWeb.ContentHelpers
 end

--- a/lib/radiator_web/views/api/episode_view.ex
+++ b/lib/radiator_web/views/api/episode_view.ex
@@ -4,6 +4,7 @@ defmodule RadiatorWeb.Api.EpisodeView do
 
   alias HAL.{Document, Link, Embed}
   alias Radiator.Directory.{Episode, Podcast, Audio}
+  import RadiatorWeb.ContentHelpers
 
   def render("show.json", assigns) do
     render(EpisodeView, "episode.json", assigns)
@@ -21,12 +22,13 @@ defmodule RadiatorWeb.Api.EpisodeView do
     })
     |> Document.add_properties(%{
       id: episode.id,
+      guid: episode.guid,
       title: episode.title,
       subtitle: episode.subtitle,
-      description: episode.description,
-      content: episode.content,
-      image: episode.image,
-      guid: episode.guid,
+      summary: episode.summary,
+      summary_html: episode.summary_html,
+      summary_source: episode.summary_source,
+      image: episode_image_url(episode),
       number: episode.number,
       published_at: episode.published_at
     })

--- a/lib/radiator_web/views/api/podcast_view.ex
+++ b/lib/radiator_web/views/api/podcast_view.ex
@@ -2,6 +2,7 @@ defmodule RadiatorWeb.Api.PodcastView do
   use RadiatorWeb, :view
   alias RadiatorWeb.Api.PodcastView
   alias HAL.{Document, Link, Embed}
+  import RadiatorWeb.ContentHelpers
 
   def render("index.json", assigns = %{podcasts: podcasts}) do
     %Document{}
@@ -36,7 +37,7 @@ defmodule RadiatorWeb.Api.PodcastView do
       subtitle: podcast.subtitle,
       summary: podcast.summary,
       author: podcast.author,
-      image: podcast.image,
+      image: podcast_image_url(podcast),
       language: podcast.language,
       last_built_at: podcast.last_built_at,
       owner_name: podcast.owner_name,

--- a/priv/repo/migrations/0400_create_episodes.exs
+++ b/priv/repo/migrations/0400_create_episodes.exs
@@ -3,16 +3,19 @@ defmodule Radiator.Repo.Migrations.CreateEpisodes do
 
   def change do
     create table(:episodes) do
+      add :guid, :string
+      add :short_id, :string
       add :title, :string
       add :subtitle, :string
-      add :description, :text
-      add :content, :text
+      add :summary, :text
+      add :summary_html, :text
+      add :summary_source, :text
+
       add :image, :string
-      add :guid, :string
       add :number, :integer
       add :published_at, :utc_datetime
+
       add :slug, :string
-      add :short_id, :string
 
       add :podcast_id, references(:podcasts, on_delete: :delete_all)
       add :audio_id, references(:audios, on_delete: :nilify_all)
@@ -20,6 +23,7 @@ defmodule Radiator.Repo.Migrations.CreateEpisodes do
       timestamps()
     end
 
+    create index(:episodes, [:guid])
     create index(:episodes, [:podcast_id])
     create index(:episodes, ["lower(short_id)"])
     create index(:episodes, ["lower(slug)", :podcast_id], unique: true)

--- a/test/radiator/feed/builder_test.exs
+++ b/test/radiator/feed/builder_test.exs
@@ -173,7 +173,8 @@ defmodule Radiator.BuilderTest do
         insert(:published_episode,
           title: "Ep 001",
           subtitle: "sub",
-          description: "desc",
+          summary: "summary",
+          summary_html: "summary_html",
           slug: "ep001",
           podcast: podcast
         )
@@ -183,7 +184,8 @@ defmodule Radiator.BuilderTest do
 
       assert "Ep 001" == xpath(rss, ~x"//item/title/text()"s)
       assert "sub" == xpath(rss, ~x"//item/itunes:subtitle/text()"s)
-      assert "desc" == xpath(rss, ~x"//item/description/text()"s)
+      assert "summary" == xpath(rss, ~x"//item/itunes:summary/text()"s)
+      assert "summary_html" == xpath(rss, ~x"//item/content:encoded/text()"s)
 
       [enclosure] = episode.audio.audio_files
 


### PR DESCRIPTION
* change episode fields `description`,`content` to `summary`,`summary_html` and `summary_source`
* updated admin, public interface and feed to reflect those
* update documentation too
* made rest api return image urls instead of image types
* made rest api capable of setting images and summary fields 

fixes #164 
needs ecto.reset