### PR TITLE
feat(rest-api): when creating audio, allow params for episode/audio publication

### DIFF
--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -484,6 +484,18 @@ DELETE /api/rest/v1/contributions/:id
 | `audio[image]`      | `file`    | Audio image.                   |
 | `audio[duration]`   | `integer` | Audio duration in milliseconds |
 
+When creating, you can send parameters for the audio publication or episode in the same request.
+
+| Name                       | Type     | Description |
+| -------------------------- | -------- | ----------- |
+| `audio_publication[title]` | `string` | Title       |
+
+| Name                                    | Type     | Description |
+| --------------------------------------- | -------- | ----------- |
+| `episode[title]`                        | `string` | Title       |
+| `episode[subtitle]`                     | `string` | Subtitle    |
+| see [Episodes](#episodes) for full list | ...      | ...         |
+
 ### Create (in network / audio publication)
 
 ```

--- a/lib/radiator/directory/audio_publication.ex
+++ b/lib/radiator/directory/audio_publication.ex
@@ -26,6 +26,7 @@ defmodule Radiator.Directory.AudioPublication do
   def changeset(audio_publication, attrs) do
     audio_publication
     |> cast(attrs, [
+      :title,
       :publish_state,
       :audio_id
     ])
@@ -39,6 +40,7 @@ defmodule Radiator.Directory.AudioPublication do
   def import_changeset(audio_publication, attrs) do
     audio_publication
     |> cast(attrs, [
+      :title,
       :publish_state,
       :published_at
     ])

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -556,17 +556,27 @@ defmodule Radiator.Directory.Editor do
     end
   end
 
-  def create_audio(actor = %Auth.User{}, episode = %Episode{}, attrs) do
+  def create_audio(
+        actor = %Auth.User{},
+        episode = %Episode{},
+        audio_attrs,
+        episode_attrs
+      ) do
     if has_permission(actor, episode, :edit) do
-      Editor.Manager.create_audio(episode, attrs)
+      Editor.Manager.create_audio(episode, audio_attrs, episode_attrs)
     else
       @not_authorized_match
     end
   end
 
-  def create_audio(actor = %Auth.User{}, network = %Network{}, attrs) do
+  def create_audio(
+        actor = %Auth.User{},
+        network = %Network{},
+        audio_attrs,
+        audio_publication_attrs
+      ) do
     if has_permission(actor, network, :edit) do
-      Editor.Manager.create_audio(network, attrs)
+      Editor.Manager.create_audio(network, audio_attrs, audio_publication_attrs)
     else
       @not_authorized_match
     end

--- a/lib/radiator_web/controllers/api/audio_controller.ex
+++ b/lib/radiator_web/controllers/api/audio_controller.ex
@@ -3,10 +3,16 @@ defmodule RadiatorWeb.Api.AudioController do
 
   alias Radiator.Directory.Editor
 
-  def create(conn, %{"network_id" => network_id, "audio" => params}) do
+  def create(conn, params = %{"network_id" => network_id}) do
     with user = current_user(conn),
          {:ok, network} <- Editor.get_network(user, network_id),
-         {:ok, audio} <- Editor.create_audio(user, network, params) do
+         {:ok, audio} <-
+           Editor.create_audio(
+             user,
+             network,
+             Map.get(params, "audio"),
+             Map.get(params, "audio_publication", %{})
+           ) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.api_audio_path(conn, :show, audio))
@@ -14,10 +20,16 @@ defmodule RadiatorWeb.Api.AudioController do
     end
   end
 
-  def create(conn, %{"episode_id" => episode_id, "audio" => params}) do
+  def create(conn, params = %{"episode_id" => episode_id}) do
     with user = current_user(conn),
          {:ok, episode} <- Editor.get_episode(user, episode_id),
-         {:ok, audio} <- Editor.create_audio(user, episode, params) do
+         {:ok, audio} <-
+           Editor.create_audio(
+             user,
+             episode,
+             Map.get(params, "audio"),
+             Map.get(params, "episode", %{})
+           ) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.api_audio_path(conn, :show, audio))


### PR DESCRIPTION
Via discussion in Slack: make it easier for API consumer to create an audio with episode / audio publication by taking parameters for the episode / audio publication while creating the audio.

/cc @Fischaela 