### PR TITLE
refactor architecture: User/Person/UserProfile

### DIFF
--- a/lib/radiator/auth/register.ex
+++ b/lib/radiator/auth/register.ex
@@ -56,24 +56,14 @@ defmodule Radiator.Auth.Register do
     |> Repo.all()
   end
 
-  # TODO: we want to always have a person associated with a user but can we do it without coupling the logic here?
+  # TODO: we want to always have a profile associated with a user but can we do it without coupling the logic here?
   def create_user(attrs \\ %{}) do
-    {person_attrs, user_attrs} = Map.split(attrs, [:nick, :image, "nick", "image"])
+    {profile_attrs, user_attrs} =
+      Map.split(attrs, [:display_name, :image, "display_name", "image"])
 
-    changeset =
-      %User{}
-      |> User.changeset(user_attrs)
-
-    display_name = Ecto.Changeset.get_field(changeset, :display_name)
-
-    person_attrs =
-      Map.merge(
-        %{display_name: display_name, name: display_name},
-        person_attrs
-      )
-
-    changeset
-    |> Ecto.Changeset.put_assoc(:person, person_attrs)
+    %User{}
+    |> User.changeset(user_attrs)
+    |> Ecto.Changeset.put_assoc(:profile, profile_attrs)
     |> Repo.insert()
   end
 

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -693,7 +693,7 @@ defmodule Radiator.Directory.Editor do
           on: p.user_id == u.id,
           join: s in Network,
           on: s.id == p.subject_id,
-          preload: [user: {u, [:person]}]
+          preload: [user: {u, [:profile]}]
 
       network_perm_query
       |> Repo.all()

--- a/lib/radiator/directory/user_profile.ex
+++ b/lib/radiator/directory/user_profile.ex
@@ -1,0 +1,33 @@
+defmodule Radiator.Directory.UserProfile do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+  import Arc.Ecto.Changeset
+  import Ecto.Query, warn: false
+
+  alias Radiator.Auth.User
+  alias Radiator.Media
+
+  schema "user_profiles" do
+    field :display_name, :string
+    field :image, Media.UserAvatar.Type
+
+    belongs_to :user, User
+
+    timestamps()
+  end
+
+  def changeset(profile = %__MODULE__{}, attrs) do
+    profile
+    |> cast(attrs, [:display_name])
+    |> validate_required([:display_name])
+    |> cast_attachments(attrs, [:image], allow_paths: true, allow_urls: true)
+  end
+
+  @doc """
+  Convenience accessor for image URL.
+  """
+  def image_url(%__MODULE__{} = subject) do
+    Media.UserAvatar.url({subject.image, subject})
+  end
+end

--- a/lib/radiator/media/user_avatar.ex
+++ b/lib/radiator/media/user_avatar.ex
@@ -1,0 +1,19 @@
+defmodule Radiator.Media.UserAvatar do
+  use Arc.Definition
+  use Arc.Ecto.Definition
+  use Radiator.Media.CoverImageBase
+
+  alias Radiator.Directory.UserProfile
+
+  def filename(version, {_file, _person}) do
+    "avatar_#{version}"
+  end
+
+  def storage_dir(_version, {_file, %UserProfile{id: id}}) when not is_nil(id) do
+    "user/#{id}"
+  end
+
+  def default_url(_, profile) do
+    "https://robohash.org/#{profile.id}?size=200x200"
+  end
+end

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -7,13 +7,13 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     Podcast,
     Network,
     Audio,
-    AudioPublication
+    AudioPublication,
+    UserProfile
   }
 
   alias Radiator.AudioMeta
   alias Radiator.AudioMeta.Chapter
   alias Radiator.Auth.User
-  alias Radiator.Contribution.Person
   alias Radiator.Media.AudioFile
 
   import Absinthe.Resolution.Helpers
@@ -117,7 +117,7 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
 
   def find_user(_, _, %{context: %{current_user: user}}) do
     user
-    |> Radiator.Repo.preload(:person)
+    |> Radiator.Repo.preload(:profile)
     |> (&{:ok, &1}).()
   end
 
@@ -385,9 +385,9 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
   def get_image_url(subject, _, _)
 
   def get_image_url(%User{} = user, _, _) do
-    user = user |> Radiator.Repo.preload(:person)
+    user = user |> Radiator.Repo.preload(:profile)
 
-    {:ok, Person.image_url(user.person)}
+    {:ok, UserProfile.image_url(user.profile)}
   end
 
   def get_image_url(%type{} = subject, _, _) do

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -40,7 +40,10 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
       resolve fn user, _, _ -> {:ok, user.name} end
     end
 
-    field :display_name, :string
+    field :display_name, :string do
+      resolve fn user, _, _ -> {:ok, user.profile.display_name} end
+    end
+
     field :email, :string
 
     field :image, :string do
@@ -54,7 +57,9 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
       resolve fn user, _, _ -> {:ok, user.name} end
     end
 
-    field :display_name, :string
+    field :display_name, :string do
+      resolve fn user, _, _ -> {:ok, user.profile.display_name} end
+    end
 
     field :image, :string do
       resolve &Resolvers.Editor.get_image_url/3

--- a/lib/radiator_web/templates/layout/_nav.html.eex
+++ b/lib/radiator_web/templates/layout/_nav.html.eex
@@ -38,9 +38,9 @@
 
     <div class="inline-flex ml-auto items-center ml-3" style="margin-left:auto">
       <%= case Guardian.Plug.current_resource(@conn) do %>
-        <% %Radiator.Auth.User{ name: name, display_name: display_name } = user -> %>
+        <% %Radiator.Auth.User{ name: name, profile: %Radiator.Directory.UserProfile{display_name: display_name} } = user -> %>
           <li class="nav-link text-center mx-2">
-            <%= img_tag(person_image_url(user.person), alt: "Avatar of #{name}", class: "w-8 h-8 rounded-full bg-tertiary mr-2") %>
+            <%= img_tag(user_image_url(user), alt: "Avatar of #{name}", class: "w-8 h-8 rounded-full bg-tertiary mr-2") %>
             <%= link to: Routes.admin_user_settings_path(@conn, :index) do %>
               <%= content_tag :span, name %>
               <%= if name != display_name do %>

--- a/lib/radiator_web/templates/shared_partials/_collaborator_list.html.eex
+++ b/lib/radiator_web/templates/shared_partials/_collaborator_list.html.eex
@@ -4,10 +4,10 @@
     <div class="flex-vertical">
     <%= for collaborator <- @collaborators do %>
         <div class="flex px-2 justify-begin h-12 border-primary border-b items-center <%= unless @current_user == collaborator.user, do: "hover:bg-highlight" %>">
-            <%= img_tag(person_image_url(collaborator.user.person), alt: "Avatar of #{collaborator.user.name}", class: "w-8 h-8 rounded-full bg-tertiary mr-2") %>
+            <%= img_tag(user_image_url(collaborator.user), alt: "Avatar of #{collaborator.user.name}", class: "w-8 h-8 rounded-full bg-tertiary mr-2") %>
             <div class="text-left mx-4 flex-shrink-0">
             <%= content_tag(:span, collaborator.user.name, class: "font-bold") %><br/>
-            <%= content_tag(:span, collaborator.user.display_name, class: "text-sm") %>
+            <%= content_tag(:span, collaborator.user.profile.display_name, class: "text-sm") %>
             </div>
             <%= render_shared_partial("_user_role_bubble.html", permission: collaborator.permission) %>
             <div class="w-full flex justify-end">

--- a/lib/radiator_web/views/helpers/content_helpers.ex
+++ b/lib/radiator_web/views/helpers/content_helpers.ex
@@ -5,10 +5,17 @@ defmodule RadiatorWeb.ContentHelpers do
     Network,
     Podcast,
     Episode,
-    Audio
+    Audio,
+    UserProfile
   }
 
+  alias Radiator.Auth.User
+
   ## public image urls
+
+  def user_image_url(%User{profile: profile}) do
+    UserProfile.image_url(profile)
+  end
 
   def person_image_url(person = %Person{}) do
     Person.image_url(person)

--- a/priv/repo/migrations/0500_add_users_table.exs
+++ b/priv/repo/migrations/0500_add_users_table.exs
@@ -5,7 +5,6 @@ defmodule Radiator.Repo.Migrations.AddUsersTable do
     create table(:auth_users) do
       add :name, :text
       add :email, :text
-      add :display_name, :text
       add :password_hash, :binary
       add :status, :string, null: false, size: 40
 

--- a/priv/repo/migrations/0550_add_user_profiles_table.exs
+++ b/priv/repo/migrations/0550_add_user_profiles_table.exs
@@ -1,0 +1,14 @@
+defmodule Radiator.Repo.Migrations.CreateUserProfiles do
+  use Ecto.Migration
+
+  def change do
+    create table(:user_profiles) do
+      add :display_name, :text
+      add :image, :text
+
+      add :user_id, references(:auth_users, on_delete: :nothing)
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,14 +4,28 @@ defmodule Radiator.Factory do
   import Radiator.Directory.Editor.Permission
 
   alias Radiator.Auth.User
-  alias Radiator.Directory.{Network, Podcast, Episode, AudioPublication}
+
+  alias Radiator.Directory.{
+    Network,
+    Podcast,
+    Episode,
+    AudioPublication,
+    UserProfile
+  }
+
   alias Radiator.Contribution.Person
 
   def user_factory do
     %User{
       name: sequence(:name, &"me-#{&1}"),
       email: sequence(:email, &"me-#{&1}@foo.com"),
-      person: build(:person)
+      profile: build(:profile)
+    }
+  end
+
+  def profile_factory do
+    %UserProfile{
+      display_name: sequence(:display_name, &"Me-#{&1}")
     }
   end
 


### PR DESCRIPTION
I detached People from Users. Instead, a UserProfile is now created together with each user.

UserProfile currently holds the `display_name` and `image`. `User` now only holds fields that are required for Auth stuff.

I wonder if we should expose this separation of User and Profile in the APIs at all? My gut says no, only expose a single "user" object in REST/gql as this separation is mainly an architecture choice to keep Auth.User clean.

I put UserProfile in `Radiator.Directory` because it is kind of public information? Otherwise we would probably a new context because neither does it fit into `Auth` nor `Contribution`.

⚠️ requires `mix ecto.reset`

issue #200 