### PR TITLE
add: local email smtp container

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ cd radiator
 docker-compose up
 ```
 
+Then access the following services:
+
+| Service  | URL                                |
+| -------- | ---------------------------------- |
+| Radiator | http://localhost:4000              |
+| Minio    | http://localhost:9000              |
+| MailHog  | http://localhost:8025              |
+| GraphiQL | http://localhost:4000/api/graphiql |
+
 **Minio Setup**
 
 - [Install minio][minio-setup]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     depends_on:
       - db
       - minio
+      - email
     environment:
       PORT: 4000
       HOST: localhost
@@ -35,11 +36,16 @@ services:
       STORAGE_ASSET_HOST: http://localhost:9000/radiator
       STORAGE_ACCESS_KEY_ID: IEKAZMUY3KX32CRJPE9R
       STORAGE_ACCESS_KEY: tXNYsfJyb8ctDgZSaIOYpndQwxOv8T+E+U0Rq3mN
-      SMTP_SERVER: smtp.mailtrap.io
-      SMTP_HOSTNAME: smtp.mailtrap.io
-      SMTP_PORT: 2525
-      SMTP_USERNAME: xxx
-      SMTP_PASSWORD: xxx
+      SMTP_SERVER: email
+      SMTP_HOSTNAME: email
+      SMTP_PORT: 1025
+      SMTP_USERNAME: ""
+      SMTP_PASSWORD: ""
+  email:
+    image: mailhog/mailhog
+    ports:
+      - 1025:1025
+      - 8025:8025
 
 volumes:
   minio_data:


### PR DESCRIPTION
mailhog is a replacement for mailtrap.io. All local, no accounts/internet required.

I don't think our radiator container should provide an smtp service. In production you probably want to use SES/SendGrid/MailGun/... or spin up an smtp container like https://hub.docker.com/r/namshi/smtp.