### PR TITLE
fix: ua_inspector crashing builds

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -94,6 +94,9 @@ config :radiator, Radiator.Scheduler,
     ]
   ]
 
+config :ua_inspector,
+  http_opts: [ssl_options: [honor_cipher_order: :undefined]]
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
There is an issue between hackney and OTP 22.1, see https://github.com/benoitc/hackney/pull/589
This is a workaround that explicitly unsets the problematic setting for ua_inspector (which uses hackney)