### PR TITLE
fix(graphql-api): hardened queries with `publicPage` and `publishedFeeds` against missing data

### DIFF
--- a/lib/radiator/directory/episode.ex
+++ b/lib/radiator/directory/episode.ex
@@ -71,9 +71,12 @@ defmodule Radiator.Directory.Episode do
 
   def public_url(%Episode{} = episode), do: public_url(episode, episode.podcast)
 
-  def public_url(%Episode{} = episode, %Podcast{} = podcast) do
-    Routes.episode_url(RadiatorWeb.Endpoint, :show, podcast.slug, episode.slug)
+  def public_url(%Episode{slug: ep_slug}, %Podcast{slug: pod_slug})
+      when is_binary(ep_slug) and is_binary(pod_slug) do
+    Routes.episode_url(RadiatorWeb.Endpoint, :show, pod_slug, ep_slug)
   end
+
+  def public_url(_, _), do: nil
 
   def construct_short_id(%Episode{} = episode, %Podcast{} = podcast) do
     podcast.short_id <>

--- a/lib/radiator/directory/podcast.ex
+++ b/lib/radiator/directory/podcast.ex
@@ -104,14 +104,18 @@ defmodule Radiator.Directory.Podcast do
     PodcastImage.url({podcast.image, podcast})
   end
 
-  def public_url(%Podcast{} = podcast) do
-    Routes.episode_url(RadiatorWeb.Endpoint, :index, podcast.slug)
+  def public_url(%Podcast{slug: pod_slug}) when is_binary(pod_slug) do
+    Routes.episode_url(RadiatorWeb.Endpoint, :index, pod_slug)
   end
 
+  def public_url(%Podcast{}), do: nil
+
   # TODO: more than one feed per podcast
-  def feed_url(%Podcast{} = podcast) do
-    Routes.feed_url(RadiatorWeb.Endpoint, :show, podcast.slug)
+  def feed_url(%Podcast{slug: pod_slug}) when is_binary(pod_slug) do
+    Routes.feed_url(RadiatorWeb.Endpoint, :show, pod_slug)
   end
+
+  def feed_url(%Podcast{}), do: nil
 
   defp validate_color(changeset, field) do
     changeset

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -201,9 +201,9 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
   # Current choice: 1
   def get_episodes(podcast = %Podcast{}, args, %{context: %{loader: loader, current_user: _user}}) do
     loader
-    |> Dataloader.load(Radiator.Directory, {:episodes, args}, podcast)
+    |> Dataloader.load(Radiator.Directory.Editor, {:episodes, args}, podcast)
     |> on_load(fn loader ->
-      items = Dataloader.get(loader, Radiator.Directory, {:episodes, args}, podcast)
+      items = Dataloader.get(loader, Radiator.Directory.Editor, {:episodes, args}, podcast)
 
       items =
         case {Map.get(args, :items_per_page), Map.get(args, :page)} do
@@ -236,6 +236,7 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     Editor.list_audio_files(user, audio)
   end
 
+  # TODO: determine if this is needed here
   def get_audio_files(audio = %Audio{}, _args, _resolution) do
     {:ok, Radiator.Directory.list_audio_files(audio)}
   end

--- a/lib/radiator_web/graphql/public/resolvers/directory.ex
+++ b/lib/radiator_web/graphql/public/resolvers/directory.ex
@@ -1,6 +1,6 @@
 defmodule RadiatorWeb.GraphQL.Public.Resolvers.Directory do
   alias Radiator.Directory
-  alias Radiator.Directory.{Episode, Podcast, Network}
+  alias Radiator.Directory.{Episode, Podcast, Network, Audio}
   alias Radiator.AudioMeta.Chapter
 
   import RadiatorWeb.FormatHelpers, only: [format_normal_playtime: 1]
@@ -84,8 +84,11 @@ defmodule RadiatorWeb.GraphQL.Public.Resolvers.Directory do
   def get_public_feeds(%Podcast{} = podcast, _args, _resolution) do
     enclosure_mime_type =
       case Directory.get_any_episode(podcast) do
-        [%Episode{} = episode] -> Episode.enclosure_mime_type(episode)
-        _ -> "audio/mpeg"
+        [%Episode{audio: %Audio{audio_files: [_enclosure]}} = episode] ->
+          Episode.enclosure_mime_type(episode)
+
+        _ ->
+          "audio/mpeg"
       end
 
     feedlist = [

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -130,7 +130,7 @@ defmodule Radiator.DirectoryTest do
     end
 
     test "publish/1 with invalid data returns error changeset" do
-      podcast = insert(:unpublished_podcast, published_at: nil)
+      podcast = insert(:podcast, published_at: nil)
       user = insert(:user) |> make_owner(podcast)
 
       assert {:error, %Ecto.Changeset{}} = Editor.Manager.publish(%{podcast | :title => nil})
@@ -139,15 +139,13 @@ defmodule Radiator.DirectoryTest do
     end
 
     test "depublish/1 sets podcasts state to :depublished" do
-      podcast = insert(:podcast)
-      published_at = podcast.published_at
+      podcast = insert(:podcast, published_at: DateTime.utc_now())
 
-      assert {:ok, %Podcast{published_at: ^published_at, publish_state: :depublished}} =
-               Editor.Manager.depublish(podcast)
+      assert {:ok, %Podcast{publish_state: :depublish}} = Editor.Manager.depublish(podcast)
     end
 
-    test "depublish_podcast/1 with invalid data returns error changeset" do
-      podcast = insert(:podcast)
+    test "depublish/1 with invalid data returns error changeset" do
+      podcast = insert(:podcast, published_at: DateTime.utc_now())
       published_at = podcast.published_at
 
       assert {:error, %Ecto.Changeset{}} = Editor.Manager.depublish(%{podcast | :title => nil})

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -130,7 +130,7 @@ defmodule Radiator.DirectoryTest do
     end
 
     test "publish/1 with invalid data returns error changeset" do
-      podcast = insert(:podcast, published_at: nil)
+      podcast = insert(:unpublished_podcast, published_at: nil)
       user = insert(:user) |> make_owner(podcast)
 
       assert {:error, %Ecto.Changeset{}} = Editor.Manager.publish(%{podcast | :title => nil})
@@ -139,13 +139,15 @@ defmodule Radiator.DirectoryTest do
     end
 
     test "depublish/1 sets podcasts state to :depublished" do
-      podcast = insert(:podcast, published_at: DateTime.utc_now())
+      podcast = insert(:podcast)
+      published_at = podcast.published_at
 
-      assert {:ok, %Podcast{publish_state: :depublish}} = Editor.Manager.depublish(podcast)
+      assert {:ok, %Podcast{published_at: ^published_at, publish_state: :depublished}} =
+               Editor.Manager.depublish(podcast)
     end
 
-    test "depublish/1 with invalid data returns error changeset" do
-      podcast = insert(:podcast, published_at: DateTime.utc_now())
+    test "depublish_podcast/1 with invalid data returns error changeset" do
+      podcast = insert(:podcast)
       published_at = podcast.published_at
 
       assert {:error, %Ecto.Changeset{}} = Editor.Manager.depublish(%{podcast | :title => nil})


### PR DESCRIPTION
* also fixed that return value of `podcast(id:) {episodes}` query includes all episodes
