### PR TITLE
cleanup publication state API

### DIFF
--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -241,6 +241,7 @@ DELETE /api/rest/v1/networks/:id/collaborators/:username
 | `podcast[owner_name]`  | `string`  |                                                                                       |
 | `podcast[owner_email]` | `string`  |                                                                                       |
 | `podcast[slug]`        | `string`  |                                                                                       |
+| `podcast[publish_state]`  | `string`  | Publication state. "drafted", "scheduled", "published" or "unpublished". |
 
 ### Create
 

--- a/lib/radiator_web/graphql/admin/resolvers/editor.ex
+++ b/lib/radiator_web/graphql/admin/resolvers/editor.ex
@@ -226,8 +226,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Resolvers.Editor do
     Editor.list_contributions(user, audio)
   end
 
-  def is_published(entity, _, _), do: {:ok, Editor.is_published(entity)}
-
   def list_chapters(%Audio{} = audio, _args, _resolution) do
     {:ok, AudioMeta.list_chapters(audio)}
   end

--- a/lib/radiator_web/graphql/admin/types.ex
+++ b/lib/radiator_web/graphql/admin/types.ex
@@ -136,12 +136,12 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
     field :last_built_at, :datetime
     field :owner_email, :string
     field :owner_name, :string
-    field :published_at, :datetime
-    field :slug, :string
 
-    field :is_published, :boolean do
-      resolve &AdminResolvers.Editor.is_published/3
-    end
+    @desc "drafted, scheduled, published, depublished"
+    field :publish_state, :string
+    field :published_at, :datetime
+
+    field :slug, :string
 
     field :public_page, :string do
       resolve &PublicResolvers.Directory.get_public_page/3
@@ -274,10 +274,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Types do
 
     field :public_page, :string do
       resolve &PublicResolvers.Directory.get_public_page/3
-    end
-
-    field :is_published, :boolean do
-      resolve &AdminResolvers.Editor.is_published/3
     end
 
     field :podcast, :podcast do

--- a/test/radiator_web/graphql/admin/schema/query/episodes_test.exs
+++ b/test/radiator_web/graphql/admin/schema/query/episodes_test.exs
@@ -84,59 +84,6 @@ defmodule RadiatorWeb.GraphQL.Admin.Schema.Query.EpisodesTest do
            }
   end
 
-  @is_published_query """
-  query ($id: ID!) {
-    episode(id: $id) {
-      id
-      isPublished
-    }
-  }
-  """
-
-  describe "is_published" do
-    test "is false for an unpublished episode", %{conn: conn, user: user} do
-      episode = insert(:episode) |> owned_by(user)
-
-      conn =
-        get conn, "/api/graphql", query: @is_published_query, variables: %{"id" => episode.id}
-
-      assert json_response(conn, 200) == %{
-               "data" => %{
-                 "episode" => %{"id" => Integer.to_string(episode.id), "isPublished" => false}
-               }
-             }
-    end
-
-    test "is true for a published episode", %{conn: conn, user: user} do
-      episode =
-        insert(:episode, publish_state: :published, published_at: DateTime.utc_now())
-        |> owned_by(user)
-
-      conn =
-        get conn, "/api/graphql", query: @is_published_query, variables: %{"id" => episode.id}
-
-      assert json_response(conn, 200) == %{
-               "data" => %{
-                 "episode" => %{"id" => Integer.to_string(episode.id), "isPublished" => true}
-               }
-             }
-    end
-
-    test "is false for published_at dates in the future", %{conn: conn, user: user} do
-      in_one_hour = DateTime.utc_now() |> DateTime.add(3600)
-      episode = insert(:episode, published_at: in_one_hour) |> owned_by(user)
-
-      conn =
-        get conn, "/api/graphql", query: @is_published_query, variables: %{"id" => episode.id}
-
-      assert json_response(conn, 200) == %{
-               "data" => %{
-                 "episode" => %{"id" => Integer.to_string(episode.id), "isPublished" => false}
-               }
-             }
-    end
-  end
-
   @episodes_in_podcast_query """
   query ($podcast_id: ID!) {
     podcast(id: $podcast_id) {


### PR DESCRIPTION
- gql: remove isPublished from episode and podcast
- gql: both episode and podcast now have a publishState accessor returning "drafted", "scheduled", "published" or "unpublished"
- REST: both episode and podcast now support the "publish_state" field on UPDATE/CREATE

fixes #237