### PR TITLE
chore: fix drone ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,8 +16,6 @@ steps:
       - name: mix
         path: /root/.mix
     commands:
-      - apt update
-      - apt install ffmpeg
       - mix local.rebar --force
       - mix local.hex --force
       - mix deps.get
@@ -34,6 +32,8 @@ steps:
       DB_HOST: "database"
       MIX_ENV: "test"
     commands:
+      - apt update
+      - apt install -y ffmpeg
       - mix format --check-formatted
       - mix ua_inspector.download --force
       - mix test

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,7 @@ steps:
       - name: mix
         path: /root/.mix
     commands:
+      - apt install ffmpeg
       - mix local.rebar --force
       - mix local.hex --force
       - mix deps.get

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,6 +16,7 @@ steps:
       - name: mix
         path: /root/.mix
     commands:
+      - apt update
       - apt install ffmpeg
       - mix local.rebar --force
       - mix local.hex --force

--- a/config/releases.exs
+++ b/config/releases.exs
@@ -40,6 +40,3 @@ config :radiator, :auth,
 config :radiator, :sandbox_mode, enabled: System.get_env("SANDBOX_MODE_ENABLED", "false")
 
 config :radiator, :instance_config, base_admin_url: System.get_env("BASE_ADMIN_URL")
-
-config :ffmpex, ffmpeg_path: "/usr/bin/ffmpeg"
-config :ffmpex, ffprobe_path: "/usr/bin/ffprobe"


### PR DESCRIPTION
Ensure ffmpeg is available in the test container.
Removes the explicit ffmpex config, which is not required.