### PR TITLE
feature: feeds as files

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -76,7 +76,7 @@ config :phoenix, :json_library, Jason
 
 config :radiator, Oban,
   repo: Radiator.Repo,
-  queues: [default: 1],
+  queues: [default: 1, feed: 1],
   prune: {:maxage, 60 * 60 * 24 * 7},
   prune_interval: 60 * 60 * 1000,
   verbose: false

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -257,7 +257,7 @@ defmodule Radiator.Directory.Editor do
   end
 
   def get_podcast(actor = %Auth.User{}, id) do
-    case Repo.get(Podcast, id) do
+    case Editor.Editor.get_podcast(id) do
       nil ->
         @not_found_match
 

--- a/lib/radiator/directory/editor/editor.ex
+++ b/lib/radiator/directory/editor/editor.ex
@@ -25,6 +25,12 @@ defmodule Radiator.Directory.Editor.Editor do
 
   require Logger
 
+  def get_podcast(id) do
+    Podcast
+    |> Repo.get(id)
+    |> Directory.Editor.preloaded_podcast()
+  end
+
   @doc """
   Gets a single podcast by its slug.
 

--- a/lib/radiator/feed/builder.ex
+++ b/lib/radiator/feed/builder.ex
@@ -1,6 +1,8 @@
 defmodule Radiator.Feed.Builder do
   @moduledoc """
   RSS Feed Builder.
+
+  Generates XML from given data object.
   """
   import XmlBuilder
 

--- a/lib/radiator/feed/generator.ex
+++ b/lib/radiator/feed/generator.ex
@@ -1,0 +1,57 @@
+defmodule Radiator.Feed.Generator do
+  @moduledoc """
+  RSS Feed Generator.
+
+  Generates XML for given podcast id.
+  """
+
+  alias Radiator.Feed.Builder
+  alias Radiator.Directory
+
+  alias Radiator.Directory.{
+    Editor,
+    Podcast
+  }
+
+  def generate(podcast_id, opts \\ []) do
+    opts =
+      opts
+      |> Keyword.put_new(:items_per_page, 50)
+      |> Keyword.put_new(:page, 1)
+
+    with podcast <- Editor.Editor.get_podcast(podcast_id),
+         episodes <- fetch_episodes(podcast) do
+
+      # TODO: there will be multiple feeds per podcast
+      feed_url = Podcast.feed_url(podcast)
+
+      Builder.new(
+        %{
+          podcast: podcast,
+          episodes: episodes,
+          urls: %{
+            main: feed_url,
+            self: feed_url,
+            page_template: page_url_template(feed_url)
+          }
+        },
+        items_per_page: opts[:items_per_page],
+        page: opts[:page]
+      )
+      |> Builder.render()
+    end
+  end
+
+  def fetch_episodes(podcast = %Podcast{}) do
+    %{podcast: podcast, order_by: :published_at, order: :desc}
+    |> Directory.list_episodes()
+    |> Directory.reject_invalid_episodes()
+  end
+
+  defp page_url_template(feed_url) do
+    feed_url
+    |> URI.parse()
+    |> Map.put(:query, "page=:page:")
+    |> URI.to_string()
+  end
+end

--- a/lib/radiator/feed/podcast_builder.ex
+++ b/lib/radiator/feed/podcast_builder.ex
@@ -32,7 +32,7 @@ defmodule Radiator.Feed.PodcastBuilder do
     |> add(contributors(podcast))
     |> add(owner(podcast))
     |> add(itunes_block())
-    # |> add(last_build_date())
+    |> add(last_build_date())
     |> Enum.reverse()
     |> Enum.concat(paging_elements(feed_data, opts))
     |> Enum.concat(episode_items(feed_data, opts))
@@ -149,5 +149,9 @@ defmodule Radiator.Feed.PodcastBuilder do
     else
       nil
     end
+  end
+
+  defp last_build_date() do
+    element(:lastBuildDate, Timex.now() |> Timex.format!("{RFC822}"))
   end
 end

--- a/lib/radiator/feed/podcast_builder.ex
+++ b/lib/radiator/feed/podcast_builder.ex
@@ -91,7 +91,7 @@ defmodule Radiator.Feed.PodcastBuilder do
   end
 
   defp episode_items(feed_data = %{episodes: episodes}, opts) do
-    with start_index <- (opts[:paging].current_page - 1) * opts[:paging].total_pages do
+    with start_index <- (opts[:paging].current_page - 1) * opts[:paging].items_per_page do
       episodes
       |> Enum.slice(start_index, opts[:items_per_page])
       |> Enum.map(fn episode ->

--- a/lib/radiator/feed/storage.ex
+++ b/lib/radiator/feed/storage.ex
@@ -6,6 +6,10 @@ defmodule Radiator.Feed.Storage do
   Generates all feed pages and stores them.
   """
   def generate(podcast_id, opts \\ []) do
+    # fetch old files
+    {:ok, old_feed_files} = Radiator.Storage.list_feed_files(podcast_id)
+
+    # generate new files
     Generator.generate(podcast_id, opts)
     |> Enum.with_index(1)
     |> Enum.each(fn {xml, page} ->
@@ -15,6 +19,27 @@ defmodule Radiator.Feed.Storage do
       store(file_path, podcast_id: podcast_id, page: page)
 
       File.rm(file_path)
+    end)
+
+    # fetch new files
+    {:ok, current_feed_files} = Radiator.Storage.list_feed_files(podcast_id)
+
+    delete_orphaned_feed_pages(old_feed_files, current_feed_files)
+
+    :ok
+  end
+
+  # if there are less pages than before, delete orphaned feed pages
+  defp delete_orphaned_feed_pages(old_files, current_files) do
+    Enum.each(old_files, fn {old_key, old_modified} ->
+      List.keyfind(current_files, old_key, 0)
+      |> case do
+        {_, new_modified} when new_modified == old_modified ->
+          Radiator.Storage.delete_file(old_key)
+
+        _ ->
+          :ok
+      end
     end)
   end
 

--- a/lib/radiator/feed/storage.ex
+++ b/lib/radiator/feed/storage.ex
@@ -1,0 +1,34 @@
+defmodule Radiator.Feed.Storage do
+  alias Radiator.Feed.Generator
+  alias Radiator.Media.FeedFile
+
+  @doc """
+  Generates all feed pages and stores them.
+  """
+  def generate(podcast_id, opts \\ []) do
+    Generator.generate(podcast_id, opts)
+    |> Enum.with_index(1)
+    |> Enum.each(fn {xml, page} ->
+      {:ok, file_path} = Temp.path()
+      :ok = File.write(file_path, xml)
+
+      store(file_path, podcast_id: podcast_id, page: page)
+
+      File.rm(file_path)
+    end)
+  end
+
+  def store(file_path, podcast_id: podcast_id, page: page) do
+    FeedFile.store({file_path, podcast_id: podcast_id, page: page})
+  end
+
+  def url(podcast_id: podcast_id, page: page) do
+    FeedFile.url(
+      {"",
+       [
+         podcast_id: podcast_id,
+         page: page
+       ]}
+    )
+  end
+end

--- a/lib/radiator/feed/worker.ex
+++ b/lib/radiator/feed/worker.ex
@@ -4,7 +4,7 @@ defmodule Radiator.Feed.Worker do
   """
   use Oban.Worker, queue: "feed", max_attempts: 2
 
-  alias Radiator.Feed.Generator
+  alias Radiator.Feed
 
   def enqueue(args) do
     args
@@ -13,6 +13,6 @@ defmodule Radiator.Feed.Worker do
   end
 
   def perform(%{"podcast_id" => podcast_id}, _job) do
-    Generator.generate(podcast_id)
+    Feed.Storage.generate(podcast_id)
   end
 end

--- a/lib/radiator/feed/worker.ex
+++ b/lib/radiator/feed/worker.ex
@@ -1,0 +1,18 @@
+defmodule Radiator.Feed.Worker do
+  @moduledoc """
+  Job Worker to generate feed files.
+  """
+  use Oban.Worker, queue: "feed", max_attempts: 2
+
+  alias Radiator.Feed.Generator
+
+  def enqueue(args) do
+    args
+    |> __MODULE__.new()
+    |> Oban.insert()
+  end
+
+  def perform(%{"podcast_id" => podcast_id}, _job) do
+    Generator.generate(podcast_id)
+  end
+end

--- a/lib/radiator/media/feed_file.ex
+++ b/lib/radiator/media/feed_file.ex
@@ -1,6 +1,10 @@
 defmodule Radiator.Media.FeedFile do
   use Arc.Definition
 
+  def filename(_version, {_file, [podcast_id: _podcast_id, page: 1]}) do
+    "feed.xml"
+  end
+
   def filename(_version, {_file, [podcast_id: _podcast_id, page: page]}) do
     "feed_page_#{page}.xml"
   end

--- a/lib/radiator/media/feed_file.ex
+++ b/lib/radiator/media/feed_file.ex
@@ -1,0 +1,15 @@
+defmodule Radiator.Media.FeedFile do
+  use Arc.Definition
+
+  def filename(_version, {_file, [podcast_id: _podcast_id, page: page]}) do
+    "feed_page_#{page}.xml"
+  end
+
+  def storage_dir(_version, {_file, [podcast_id: podcast_id, page: _page]}) do
+    "feed/#{podcast_id}"
+  end
+
+  def s3_object_headers(_version, {_file, _scope}) do
+    [content_type: "text/xml"]
+  end
+end

--- a/lib/radiator/storage/storage.ex
+++ b/lib/radiator/storage/storage.ex
@@ -75,6 +75,21 @@ defmodule Radiator.Storage do
     {:ok, key}
   end
 
+  def list_feed_files(podcast_id) do
+    {:ok, %{status_code: 200, body: %{contents: contents}, headers: _headers}} =
+      S3.list_objects(bucket(), prefix: "feed/#{podcast_id}") |> ExAws.request()
+
+    contents = contents |> Enum.map(fn f -> {f.key, f.last_modified} end)
+
+    {:ok, contents}
+  end
+
+  def delete_feed(podcast_id) do
+    {:ok, _} = S3.delete_object(bucket(), "/feed/#{podcast_id}") |> ExAws.request()
+
+    {:ok, podcast_id}
+  end
+
   @doc """
   Full storage URL for a given file name
   """

--- a/lib/radiator/storage/storage.ex
+++ b/lib/radiator/storage/storage.ex
@@ -84,12 +84,6 @@ defmodule Radiator.Storage do
     {:ok, contents}
   end
 
-  def delete_feed(podcast_id) do
-    {:ok, _} = S3.delete_object(bucket(), "/feed/#{podcast_id}") |> ExAws.request()
-
-    {:ok, podcast_id}
-  end
-
   @doc """
   Full storage URL for a given file name
   """

--- a/lib/radiator_web/controllers/public/feed_controller.ex
+++ b/lib/radiator_web/controllers/public/feed_controller.ex
@@ -4,8 +4,7 @@ defmodule RadiatorWeb.Public.FeedController do
   alias Radiator.Directory
   alias Radiator.Directory.Podcast
   alias Radiator.Feed.Builder
-
-  @items_per_page 50
+  alias Radiator.Feed.Generator
 
   action_fallback RadiatorWeb.FallbackController
 
@@ -17,35 +16,7 @@ defmodule RadiatorWeb.Public.FeedController do
   end
 
   def show(conn, %{"page" => page}, %{current_podcast: podcast}) do
-    with episodes <-
-           Directory.list_episodes(%{podcast: podcast, order_by: :published_at, order: :desc})
-           |> Directory.reject_invalid_episodes(),
-         page <- String.to_integer(page) do
-      # I wonder where I could extract that to.
-      #  - Directory.Feed context would be my first choice but that
-      # should not know about conn. And if I pass in the URL map
-      # I don't gain much.
-      #  - View Layer? That's too late in the stack I think?
-
-      # TODO: multpile feeds per podcast, we need to know who we are
-      feed_url = Podcast.feed_url(podcast)
-
-      xml =
-        Builder.new(
-          %{
-            podcast: podcast,
-            episodes: episodes,
-            urls: %{
-              main: feed_url,
-              self: feed_url,
-              page_template: page_url_template(feed_url)
-            }
-          },
-          items_per_page: @items_per_page,
-          page: page
-        )
-        |> Builder.render()
-
+    with xml <- Generator.generate(podcast.id, page: String.to_integer(page)) do
       conn
       |> put_resp_content_type("text/xml")
       |> send_resp(200, xml)
@@ -55,11 +26,4 @@ defmodule RadiatorWeb.Public.FeedController do
   def show(_, %{"page" => _page}, _), do: {:error, :not_found}
   # todo: enforce canonical URL when ?page=1 is set
   def show(conn, params, assigns), do: show(conn, Map.put(params, "page", "1"), assigns)
-
-  defp page_url_template(feed_url) do
-    feed_url
-    |> URI.parse()
-    |> Map.put(:query, "page=:page:")
-    |> URI.to_string()
-  end
 end

--- a/lib/radiator_web/controllers/public/feed_controller.ex
+++ b/lib/radiator_web/controllers/public/feed_controller.ex
@@ -1,10 +1,7 @@
 defmodule RadiatorWeb.Public.FeedController do
   use RadiatorWeb, :controller
 
-  alias Radiator.Directory
-  alias Radiator.Directory.Podcast
-  alias Radiator.Feed.Builder
-  alias Radiator.Feed.Generator
+  alias Radiator.Feed
 
   action_fallback RadiatorWeb.FallbackController
 
@@ -16,11 +13,10 @@ defmodule RadiatorWeb.Public.FeedController do
   end
 
   def show(conn, %{"page" => page}, %{current_podcast: podcast}) do
-    with xml <- Generator.generate(podcast.id, page: String.to_integer(page)) do
-      conn
-      |> put_resp_content_type("text/xml")
-      |> send_resp(200, xml)
-    end
+    # todo: track request before redirecting
+    conn
+    |> put_status(307)
+    |> redirect(external: Feed.Storage.url(podcast_id: podcast.id, page: String.to_integer(page)))
   end
 
   def show(_, %{"page" => _page}, _), do: {:error, :not_found}

--- a/lib/radiator_web/controllers/public/feed_controller.ex
+++ b/lib/radiator_web/controllers/public/feed_controller.ex
@@ -12,6 +12,18 @@ defmodule RadiatorWeb.Public.FeedController do
     apply(__MODULE__, action_name(conn), args)
   end
 
+  @doc """
+  FIXME: The controller doesn't know if the feed file is actually available.
+  And I think it shouldn't (a proper check before redirect would be expensive).
+  The way it should be is that a podcast is only really published/public once the
+  feed is available. Which means publications is a multi-step-process?
+
+  - generate the feed
+  - verify all is good
+  - set podcast status to published
+
+  If we don't enforce this there may be podcasts for a few seconds/minutes without a feed.
+  """
   def show(conn, %{"page" => page}, %{current_podcast: podcast}) do
     # todo: track request before redirecting
     conn

--- a/lib/radiator_web/controllers/public/feed_controller.ex
+++ b/lib/radiator_web/controllers/public/feed_controller.ex
@@ -16,7 +16,7 @@ defmodule RadiatorWeb.Public.FeedController do
   FIXME: The controller doesn't know if the feed file is actually available.
   And I think it shouldn't (a proper check before redirect would be expensive).
   The way it should be is that a podcast is only really published/public once the
-  feed is available. Which means publications is a multi-step-process?
+  feed is available. Which means publication is a multi-step-process?
 
   - generate the feed
   - verify all is good

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,9 @@ defmodule Radiator.MixProject do
       # job processor
       {:oban, "~> 0.8"},
       # cron-like job scheduler
-      {:quantum, "~> 2.3"}
+      {:quantum, "~> 2.3"},
+      # create and use temporary files/directories
+      {:temp, "~> 0.4"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -79,6 +79,7 @@
   "swarm": {:hex, :swarm, "3.4.0", "64f8b30055d74640d2186c66354b33b999438692a91be275bb89cdc7e401f448", [:mix], [{:gen_state_machine, "~> 2.0", [hex: :gen_state_machine, repo: "hexpm", optional: false]}, {:libring, "~> 1.0", [hex: :libring, repo: "hexpm", optional: false]}], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.6", "fc3e91ec5dd7c787b6195757fbcf0abc670cee1e4172687b45183032221b66b8", [:mix], [], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
+  "temp": {:hex, :temp, "0.4.7", "2c78482cc2294020a4bc0c95950b907ff386523367d4e63308a252feffbea9f2", [:mix], [], "hexpm"},
   "timex": {:hex, :timex, "3.6.1", "efdf56d0e67a6b956cc57774353b0329c8ab7726766a11547e529357ffdc1d56", [:mix], [{:combine, "~> 0.10", [hex: :combine, repo: "hexpm", optional: false]}, {:gettext, "~> 0.10", [hex: :gettext, repo: "hexpm", optional: false]}, {:tzdata, "~> 0.1.8 or ~> 0.5 or ~> 1.0.0", [hex: :tzdata, repo: "hexpm", optional: false]}], "hexpm"},
   "tzdata": {:hex, :tzdata, "1.0.1", "f6027a331af7d837471248e62733c6ebee86a72e57c613aa071ebb1f750fc71a", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "ua_inspector": {:hex, :ua_inspector, "1.2.0", "970339552466e6a814cc6339f582d34c6814f28952bb4513f29b1d0a1dbc8847", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}, {:yamerl, "~> 0.7", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/radiator_web/controllers/api/audio_file_controller_test.exs
+++ b/test/radiator_web/controllers/api/audio_file_controller_test.exs
@@ -1,8 +1,6 @@
 defmodule RadiatorWeb.Api.AudioFileControllerTest do
   use RadiatorWeb.ConnCase
 
-  import Radiator.Factory
-
   def setup_user_and_conn(%{conn: conn}) do
     user = Radiator.TestEntries.user()
 

--- a/test/radiator_web/controllers/feed_controller_test.exs
+++ b/test/radiator_web/controllers/feed_controller_test.exs
@@ -7,36 +7,12 @@ defmodule RadiatorWeb.FeedControllerTest do
     test "renders the podcast feed" do
       podcast = insert(:podcast, title: "ACME Cast", short_id: "ACME", slug: "acme") |> publish()
 
-      episode = insert(:episode, title: "E001", podcast: podcast, slug: "e001") |> publish()
+      _episode = insert(:episode, title: "E001", podcast: podcast, slug: "e001") |> publish()
 
       conn = build_conn()
       conn = get(conn, Routes.feed_path(conn, :show, podcast.slug))
 
-      response = response(conn, 200)
-
-      assert response =~ podcast.title
-      assert response =~ episode.title
-    end
-
-    test "shows not include episodes without enclosure" do
-      podcast = insert(:podcast, title: "ACME Cast", short_id: "ACME", slug: "acme") |> publish()
-
-      episode =
-        insert(:episode,
-          title: "E001",
-          podcast: podcast,
-          audio: build(:empty_audio),
-          slug: "e001"
-        )
-        |> publish()
-
-      conn = build_conn()
-      conn = get(conn, Routes.feed_path(conn, :show, podcast.slug))
-
-      response = response(conn, 200)
-
-      assert response =~ podcast.title
-      refute response =~ episode.title
+      assert redirected_to(conn, 307) =~ ".xml"
     end
   end
 end


### PR DESCRIPTION
Instead of serving feeds on-demand, static feed files are generated every time podcast or episode data changes, and stored on disk. Public feed URLs are dynamic and incoming requests redirected to the static file, similar to how audio files are handled.

closes #259 