### PR TITLE
RESTful publication actions

### DIFF
--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -321,7 +321,6 @@ DELETE /api/rest/v1/networks/:id/collaborators/:username
 | `podcast[owner_name]`    | `string`  |                                                                                                   |
 | `podcast[owner_email]`   | `string`  |                                                                                                   |
 | `podcast[slug]`          | `string`  |                                                                                                   |
-| `podcast[publish_state]` | `string`  | Publication state. "drafted", "scheduled", "published" or "unpublished".                          |
 
 ### Create
 

--- a/guides/rest_api.md
+++ b/guides/rest_api.md
@@ -308,19 +308,19 @@ DELETE /api/rest/v1/networks/:id/collaborators/:username
 
 ### Parameters for Create & Update
 
-| Name                     | Type      | Description                                                                                       |
-| ------------------------ | --------- | ------------------------------------------------------------------------------------------------- |
-| `podcast[title]`         | `string`  | **Required.**                                                                                     |
-| `podcast[network_id]`    | `integer` | **Required.**                                                                                     |
-| `podcast[short_id]`      | `string`  | Short ID for this podcast, also used as slug. Not unique. 2-5 characters usually, e.g. FS,FAN,ATP |
-| `podcast[subtitle]`      | `string`  | Attention grabbing one liner appearing in lists/directories                                       |
-| `podcast[summary]`       | `string`  | Short multiline description, appears in iTunes Preview                                            |
-| `podcast[image]`         | `Image`   | Cover Image                                                                                       |
-| `podcast[author]`        | `string`  | One line description of publisher                                                                 |
-| `podcast[language]`      | `string`  | ISO 639-1                                                                                         |
-| `podcast[owner_name]`    | `string`  |                                                                                                   |
-| `podcast[owner_email]`   | `string`  |                                                                                                   |
-| `podcast[slug]`          | `string`  |                                                                                                   |
+| Name                   | Type      | Description                                                                                       |
+| ---------------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| `podcast[title]`       | `string`  | **Required.**                                                                                     |
+| `podcast[network_id]`  | `integer` | **Required.**                                                                                     |
+| `podcast[short_id]`    | `string`  | Short ID for this podcast, also used as slug. Not unique. 2-5 characters usually, e.g. FS,FAN,ATP |
+| `podcast[subtitle]`    | `string`  | Attention grabbing one liner appearing in lists/directories                                       |
+| `podcast[summary]`     | `string`  | Short multiline description, appears in iTunes Preview                                            |
+| `podcast[image]`       | `Image`   | Cover Image                                                                                       |
+| `podcast[author]`      | `string`  | One line description of publisher                                                                 |
+| `podcast[language]`    | `string`  | ISO 639-1                                                                                         |
+| `podcast[owner_name]`  | `string`  |                                                                                                   |
+| `podcast[owner_email]` | `string`  |                                                                                                   |
+| `podcast[slug]`        | `string`  |                                                                                                   |
 
 ### Create
 
@@ -344,6 +344,18 @@ PATCH /api/rest/v1/podcasts/:id
 
 ```
 DELETE /api/rest/v1/podcasts/:id
+```
+
+### Publish
+
+```
+PUT /api/rest/v1/podcasts/:id/publish
+```
+
+### Depublish
+
+```
+PUT /api/rest/v1/podcasts/:id/depublish
 ```
 
 ## Podcasts Collaborators
@@ -385,18 +397,17 @@ DELETE /api/rest/v1/podcasts/:id/collaborators/:username
 
 ### Parameters for Create & Update
 
-| Name                      | Type      | Description                                                              |
-| ------------------------- | --------- | ------------------------------------------------------------------------ |
-| `episode[title]`          | `string`  | **Required.**                                                            |
-| `episode[podcast_id]`     | `integer` | **Required.**                                                            |
-| `episode[short_id]`       | `string`  | Full combined short id, usually short_id + Number. Not unique.           |
-| `episode[guid]`           | `string`  | guid, prefilled on publish if unspecified                                |
-| `episode[subtitle]`       | `string`  | One line description of the episode                                      |
-| `episode[summary]`        | `text`    | Multiline description, plain text only                                   |
-| `episode[summary_html]`   | `text`    | Multiline description, html. Will be put in `content:encoded` in a feed  |
-| `episode[summary_source]` | `text`    | Multiline description, arbitrary format chosen by frontends.             |
-| `episode[number]`         | `integer` | Episode "Track" number, will be put in `itunes:episode` in the feed      |
-| `episode[publish_state]`  | `string`  | Publication state. "drafted", "scheduled", "published" or "unpublished". |
+| Name                      | Type      | Description                                                             |
+| ------------------------- | --------- | ----------------------------------------------------------------------- |
+| `episode[title]`          | `string`  | **Required.**                                                           |
+| `episode[podcast_id]`     | `integer` | **Required.**                                                           |
+| `episode[short_id]`       | `string`  | Full combined short id, usually short_id + Number. Not unique.          |
+| `episode[guid]`           | `string`  | guid, prefilled on publish if unspecified                               |
+| `episode[subtitle]`       | `string`  | One line description of the episode                                     |
+| `episode[summary]`        | `text`    | Multiline description, plain text only                                  |
+| `episode[summary_html]`   | `text`    | Multiline description, html. Will be put in `content:encoded` in a feed |
+| `episode[summary_source]` | `text`    | Multiline description, arbitrary format chosen by frontends.            |
+| `episode[number]`         | `integer` | Episode "Track" number, will be put in `itunes:episode` in the feed     |
 
 ### Create
 
@@ -422,18 +433,28 @@ PATCH /api/rest/v1/episodes/:id
 DELETE /api/rest/v1/episodes/:id
 ```
 
+### Publish
+
+```
+PUT /api/rest/v1/episodes/:id/publish
+```
+
+### Depublish
+
+```
+PUT /api/rest/v1/episodes/:id/depublish
+```
+
 ## AudioPublications
 
 Represents an Audio in a Network
 
 ### Parameters for Create & Update
 
-| Name                               | Type       | Description                                                              |
-| ---------------------------------- | ---------- | ------------------------------------------------------------------------ |
-| `audio_publication[publish_state]` | `string`   | Publication state. "drafted", "scheduled", "published" or "unpublished". |
-| `audio_publication[published_at]`  | `datetime` | publication date (readonly, is set automatically on first publication)   |
-| `audio_publication[network_id]`    | `string`   | network id (readonly)                                                    |
-| `audio_publication[audio_id]`      | `string`   | audio id (readonly)                                                      |
+| Name                            | Type     | Description           |
+| ------------------------------- | -------- | --------------------- |
+| `audio_publication[network_id]` | `string` | network id (readonly) |
+| `audio_publication[audio_id]`   | `string` | audio id (readonly)   |
 
 ### Index
 
@@ -461,6 +482,18 @@ PATCH /api/rest/v1/audio_publications/:id
 
 ```
 DELETE /api/rest/v1/audio_publications/:id
+```
+
+### Publish
+
+```
+PUT /api/rest/v1/audio_publications/:id/publish
+```
+
+### Depublish
+
+```
+PUT /api/rest/v1/audio_publications/:id/depublish
 ```
 
 ## People

--- a/lib/radiator/directory/audio_publication.ex
+++ b/lib/radiator/directory/audio_publication.ex
@@ -30,10 +30,19 @@ defmodule Radiator.Directory.AudioPublication do
     audio_publication
     |> cast(attrs, [
       :title,
-      :publish_state,
       :audio_id,
       :title,
       :slug
+    ])
+    |> TitleSlug.maybe_generate_slug()
+    |> TitleSlug.unique_constraint()
+  end
+
+  def publication_changeset(audio_publication, attrs) do
+    audio_publication
+    |> cast(attrs, [
+      :publish_state,
+      :published_at
     ])
     |> validate_publish_state()
     |> maybe_set_published_at()

--- a/lib/radiator/directory/editor.ex
+++ b/lib/radiator/directory/editor.ex
@@ -359,6 +359,22 @@ defmodule Radiator.Directory.Editor do
     end
   end
 
+  def publish_audio_publication(actor = %Auth.User{}, audio_publication = %AudioPublication{}) do
+    if has_permission(actor, audio_publication, :manage) do
+      Editor.Manager.publish(audio_publication)
+    else
+      @not_authorized_match
+    end
+  end
+
+  def depublish_audio_publication(actor = %Auth.User{}, audio_publication = %AudioPublication{}) do
+    if has_permission(actor, audio_publication, :manage) do
+      Editor.Manager.depublish(audio_publication)
+    else
+      @not_authorized_match
+    end
+  end
+
   def delete_audio_publication(actor = %Auth.User{}, audio_publication = %AudioPublication{}) do
     if can_access_audio_publication(actor, audio_publication, :own) do
       Editor.Owner.delete_audio_publication(audio_publication)

--- a/lib/radiator/directory/editor/manager.ex
+++ b/lib/radiator/directory/editor/manager.ex
@@ -302,7 +302,7 @@ defmodule Radiator.Directory.Editor.Manager do
   def publish(subject = %type{}) when type in [Podcast, Episode, AudioPublication] do
     result =
       subject
-      |> type.changeset(%{publish_state: :published})
+      |> type.publication_changeset(%{publish_state: :published})
       |> Repo.update()
 
     refresh_feed_cache(subject)
@@ -324,7 +324,7 @@ defmodule Radiator.Directory.Editor.Manager do
   def depublish(subject = %type{}) when type in [Podcast, Episode, AudioPublication] do
     result =
       subject
-      |> type.changeset(%{publish_state: :depublished})
+      |> type.publication_changeset(%{publish_state: :depublished})
       |> Repo.update()
 
     refresh_feed_cache(subject)

--- a/lib/radiator/directory/episode.ex
+++ b/lib/radiator/directory/episode.ex
@@ -53,8 +53,6 @@ defmodule Radiator.Directory.Episode do
       :summary_source,
       :guid,
       :number,
-      :publish_state,
-      :published_at,
       :slug,
       :short_id,
       :podcast_id,
@@ -63,6 +61,16 @@ defmodule Radiator.Directory.Episode do
     |> validate_required([:title])
     |> set_guid_if_missing()
     |> create_audio_from_enclosure()
+    |> TitleSlug.maybe_generate_slug()
+    |> TitleSlug.unique_constraint()
+  end
+
+  def publication_changeset(episode, attrs) do
+    episode
+    |> cast(attrs, [
+      :publish_state,
+      :published_at
+    ])
     |> validate_publish_state()
     |> maybe_set_published_at()
     |> TitleSlug.maybe_generate_slug()

--- a/lib/radiator/directory/podcast.ex
+++ b/lib/radiator/directory/podcast.ex
@@ -61,8 +61,6 @@ defmodule Radiator.Directory.Podcast do
       :owner_name,
       :owner_email,
       :language,
-      :publish_state,
-      :published_at,
       :last_built_at,
       :slug,
       :main_color,
@@ -73,10 +71,18 @@ defmodule Radiator.Directory.Podcast do
     |> validate_required([:title])
     |> validate_color(:main_color)
     |> postprocess_short_id()
-    |> validate_publish_state()
-    |> maybe_set_published_at()
     |> TitleSlug.maybe_generate_slug()
     |> TitleSlug.unique_constraint()
+  end
+
+  def publication_changeset(podcast, attrs) do
+    podcast
+    |> cast(attrs, [
+      :publish_state,
+      :published_at
+    ])
+    |> validate_publish_state()
+    |> maybe_set_published_at()
   end
 
   @doc """

--- a/lib/radiator/directory/podcast.ex
+++ b/lib/radiator/directory/podcast.ex
@@ -83,6 +83,8 @@ defmodule Radiator.Directory.Podcast do
     ])
     |> validate_publish_state()
     |> maybe_set_published_at()
+    |> TitleSlug.maybe_generate_slug()
+    |> TitleSlug.unique_constraint()
   end
 
   @doc """

--- a/lib/radiator_web/controllers/api/audio_publication_controller.ex
+++ b/lib/radiator_web/controllers/api/audio_publication_controller.ex
@@ -52,4 +52,20 @@ defmodule RadiatorWeb.Api.AudioPublicationController do
       error -> error
     end
   end
+
+  def publish(conn, %{"id" => id}) do
+    with user = current_user(conn),
+         {:ok, audio_publication} <- Editor.get_audio_publication(user, id),
+         {:ok, _audio_publication} <- Editor.publish_audio_publication(user, audio_publication) do
+      send_no_content(conn)
+    end
+  end
+
+  def depublish(conn, %{"id" => id}) do
+    with user = current_user(conn),
+         {:ok, audio_publication} <- Editor.get_audio_publication(user, id),
+         {:ok, _audio_publication} <- Editor.depublish_audio_publication(user, audio_publication) do
+      send_no_content(conn)
+    end
+  end
 end

--- a/lib/radiator_web/controllers/api/episode_controller.ex
+++ b/lib/radiator_web/controllers/api/episode_controller.ex
@@ -39,4 +39,20 @@ defmodule RadiatorWeb.Api.EpisodeController do
       error -> error
     end
   end
+
+  def publish(conn, %{"episode_id" => id}) do
+    with user = current_user(conn),
+         {:ok, episode} <- Editor.get_episode(user, id),
+         {:ok, _episode} <- Editor.publish_episode(user, episode) do
+      send_no_content(conn)
+    end
+  end
+
+  def depublish(conn, %{"episode_id" => id}) do
+    with user = current_user(conn),
+         {:ok, episode} <- Editor.get_episode(user, id),
+         {:ok, _episode} <- Editor.depublish_episode(user, episode) do
+      send_no_content(conn)
+    end
+  end
 end

--- a/lib/radiator_web/controllers/api/podcast_controller.ex
+++ b/lib/radiator_web/controllers/api/podcast_controller.ex
@@ -39,4 +39,20 @@ defmodule RadiatorWeb.Api.PodcastController do
       error -> error
     end
   end
+
+  def publish(conn, %{"id" => id}) do
+    with user = current_user(conn),
+         {:ok, podcast} <- Editor.get_podcast(user, id),
+         {:ok, _podcast} <- Editor.publish_podcast(user, podcast) do
+      send_no_content(conn)
+    end
+  end
+
+  def depublish(conn, %{"id" => id}) do
+    with user = current_user(conn),
+         {:ok, podcast} <- Editor.get_podcast(user, id),
+         {:ok, _podcast} <- Editor.depublish_podcast(user, podcast) do
+      send_no_content(conn)
+    end
+  end
 end

--- a/lib/radiator_web/helpers/rest_api_helpers.ex
+++ b/lib/radiator_web/helpers/rest_api_helpers.ex
@@ -6,8 +6,11 @@ defmodule RadiatorWeb.Helpers.RestApiHelpers do
   import Plug.Conn, only: [send_resp: 3]
 
   def send_delete_resp(conn) do
-    conn
-    |> send_resp(204, "")
+    send_no_content(conn)
+  end
+
+  def send_no_content(conn) do
+    send_resp(conn, 204, "")
   end
 
   def send_single_message_success(conn, message \\ "ok") do

--- a/lib/radiator_web/router.ex
+++ b/lib/radiator_web/router.ex
@@ -124,11 +124,17 @@ defmodule RadiatorWeb.Router do
     end
 
     resources "/episodes", EpisodeController, only: [:show, :create, :update, :delete] do
+      put "/publish", EpisodeController, :publish
+      put "/depublish", EpisodeController, :depublish
+
       resources "/audios", AudioController, only: [:create]
     end
 
     resources "/audio_publications", AudioPublicationController,
-      only: [:index, :show, :update, :delete]
+      only: [:index, :show, :update, :delete] do
+      put "/publish", AudioPublicationController, :publish
+      put "/depublish", AudioPublicationController, :depublish
+    end
 
     resources "/people", PersonController, only: [:index, :show, :create, :update, :delete]
 

--- a/lib/radiator_web/router.ex
+++ b/lib/radiator_web/router.ex
@@ -117,6 +117,9 @@ defmodule RadiatorWeb.Router do
     end
 
     resources "/podcasts", PodcastController, only: [:show, :create, :update, :delete] do
+      put "/publish", PodcastController, :publish
+      put "/depublish", PodcastController, :depublish
+
       resources "/collaborators", CollaboratorController, only: [:show, :create, :update, :delete]
     end
 

--- a/test/radiator/directory/directory_test.exs
+++ b/test/radiator/directory/directory_test.exs
@@ -130,30 +130,12 @@ defmodule Radiator.DirectoryTest do
       assert published_podcast3.slug == "#{existing_podcast.slug}-3"
     end
 
-    test "publish/1 with invalid data returns error changeset" do
-      podcast = insert(:podcast, published_at: nil)
-      user = insert(:user) |> make_owner(podcast)
-
-      assert {:error, %Ecto.Changeset{}} = Editor.Manager.publish(%{podcast | :title => nil})
-
-      assert {:ok, %Podcast{published_at: nil}} = Editor.get_podcast(user, podcast.id)
-    end
-
     test "depublish/1 sets podcasts state to :depublished" do
       podcast = insert(:podcast) |> publish()
       published_at = podcast.published_at
 
       assert {:ok, %Podcast{published_at: ^published_at, publish_state: :depublished}} =
                Editor.Manager.depublish(podcast)
-    end
-
-    test "depublish_podcast/1 with invalid data returns error changeset" do
-      podcast = insert(:podcast) |> publish()
-      published_at = podcast.published_at
-
-      assert {:error, %Ecto.Changeset{}} = Editor.Manager.depublish(%{podcast | :title => nil})
-
-      assert %Podcast{published_at: ^published_at} = Directory.get_podcast(podcast.id)
     end
   end
 
@@ -213,11 +195,7 @@ defmodule Radiator.DirectoryTest do
 
       assert updated_episode.slug == nil
 
-      {:ok, published_episode} =
-        Editor.Manager.update_episode(updated_episode, %{
-          publish_state: :published,
-          published_at: DateTime.utc_now()
-        })
+      {:ok, published_episode} = Editor.Manager.publish(updated_episode)
 
       assert String.length(published_episode.slug) > 0
     end

--- a/test/radiator/directory/title_slug_test.exs
+++ b/test/radiator/directory/title_slug_test.exs
@@ -23,7 +23,7 @@ defmodule Radiator.Directory.TitleSlugTest do
     test "extracts the title of a given Episode changeset, when publish_state is published" do
       episode = insert(:episode)
       title = episode.title
-      changeset = Episode.changeset(episode, %{publish_state: :published})
+      changeset = Episode.publication_changeset(episode, %{publish_state: :published})
 
       assert [^title] = TitleSlug.get_sources(changeset, [])
     end
@@ -54,7 +54,7 @@ defmodule Radiator.Directory.TitleSlugTest do
 
     test "generates a slug from the given sources and Episode changeset" do
       episode = insert(:episode, title: "Episode Slug Test")
-      changeset = Episode.changeset(episode, %{publish_state: :published})
+      changeset = Episode.publication_changeset(episode, %{publish_state: :published})
       sources = TitleSlug.get_sources(changeset, [])
 
       assert "episode-slug-test" == TitleSlug.build_slug(sources, changeset)
@@ -94,15 +94,16 @@ defmodule Radiator.Directory.TitleSlugTest do
       existing_episode =
         insert(:episode, %{
           title: "Sequential Episode Slug Test",
-          slug: "sequential-episode-slug-test",
-          publish_state: :published
+          slug: "sequential-episode-slug-test"
         })
+        |> publish()
+
+      podcast = existing_episode.podcast
 
       changeset =
-        insert(:episode, title: existing_episode.title, publish_state: :drafted)
-        |> Episode.changeset(%{
-          publish_state: :published,
-          podcast_id: existing_episode.podcast_id
+        insert(:episode, title: existing_episode.title, podcast: podcast, publish_state: :drafted)
+        |> Episode.publication_changeset(%{
+          publish_state: :published
         })
 
       sources = TitleSlug.get_sources(changeset, [])

--- a/test/radiator_web/controllers/api/integration_test.exs
+++ b/test/radiator_web/controllers/api/integration_test.exs
@@ -73,9 +73,16 @@ defmodule RadiatorWeb.Api.IntegrationTest do
       conn =
         conn
         |> recycle()
-        |> patch(Routes.api_episode_path(conn, :update, episode["id"]), %{
-          episode: %{publish_state: "published"}
-        })
+        |> put(Routes.api_episode_episode_path(conn, :publish, episode["id"]))
+
+      assert response(conn, :no_content)
+
+      # get episode
+
+      conn =
+        conn
+        |> recycle()
+        |> get(Routes.api_episode_path(conn, :show, episode["id"]))
 
       assert %{"publish_state" => "published", "published_at" => published_at, "slug" => slug} =
                json_response(conn, :ok)


### PR DESCRIPTION
Adds dedicated publish & depublish endpoints to REST API for Podcast, Episode and AudioPublication.

Decided on `PUT` routes (`PUT /api/rest/v1/[subject]/:id/[publish|depublish]`) because that's what Github uses for [starring gists](https://developer.github.com/v3/gists/#star-a-gist) which is a somewhat similar intent.