### PR TITLE
Connect outline nodes to episodes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Podlove
+Copyright (c) 2024 Podlove
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -22,14 +22,14 @@ defmodule Radiator.Outline.Node do
   end
 
   @required_fields [
-    :content
+    :content,
+    :episode_id
   ]
 
   @optional_fields [
     :creator_id,
     :parent_id,
-    :prev_id,
-    :episode_id # FIXME: should be required
+    :prev_id
   ]
 
   @all_fields @optional_fields ++ @required_fields

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -5,6 +5,7 @@ defmodule Radiator.Outline.Node do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias Radiator.Podcast.Episode
 
   @derive {Jason.Encoder, only: [:uuid, :content, :creator_id, :parent_id, :prev_id]}
 
@@ -14,6 +15,8 @@ defmodule Radiator.Outline.Node do
     field :creator_id, :integer
     field :parent_id, Ecto.UUID
     field :prev_id, Ecto.UUID
+
+    belongs_to :episode, Episode
 
     timestamps(type: :utc_datetime)
   end
@@ -25,7 +28,8 @@ defmodule Radiator.Outline.Node do
   @optional_fields [
     :creator_id,
     :parent_id,
-    :prev_id
+    :prev_id,
+    :episode_id # FIXME: should be required
   ]
 
   @all_fields @optional_fields ++ @required_fields

--- a/lib/radiator/podcast.ex
+++ b/lib/radiator/podcast.ex
@@ -227,7 +227,8 @@ defmodule Radiator.Podcast do
   def get_episode!(id), do: Repo.get!(Episode, id)
 
   @doc """
-    Returns the newest (TODO: not published ) episode for a show.
+    Finds the newest (TODO: not published ) episode for a show.
+    Returns %Episode{} or `nil` and expects an id of the show.
 
     ## Examples
 

--- a/lib/radiator/podcast.ex
+++ b/lib/radiator/podcast.ex
@@ -227,6 +227,26 @@ defmodule Radiator.Podcast do
   def get_episode!(id), do: Repo.get!(Episode, id)
 
   @doc """
+    Returns the newest (TODO: not published ) episode for a show.
+
+    ## Examples
+
+        iex> get_current_episode_for_show(123)
+        %Episode{}
+
+        iex> get_current_episode_for_show(456)
+        nil
+
+  """
+  def get_current_episode_for_show(nil), do: nil
+
+  def get_current_episode_for_show(show_id) do
+    Repo.one(
+      from e in Episode, where: e.show_id == ^show_id, order_by: [desc: e.number], limit: 1
+    )
+  end
+
+  @doc """
   Creates a episode.
 
   ## Examples

--- a/lib/radiator/podcast.ex
+++ b/lib/radiator/podcast.ex
@@ -239,9 +239,31 @@ defmodule Radiator.Podcast do
 
   """
   def create_episode(attrs \\ %{}) do
+    attrs_with_number = set_number(attrs)
+
     %Episode{}
-    |> Episode.changeset(attrs)
+    |> Episode.changeset(attrs_with_number)
     |> Repo.insert()
+  end
+
+  defp set_number(%{number: _number} = attrs), do: attrs
+
+  defp set_number(%{show_id: show_id} = episode_attrs) do
+    number = get_highest_number(show_id) + 1
+    Map.put(episode_attrs, :number, number)
+  end
+
+  defp set_number(%{} = episode_attrs) do
+    Map.put(episode_attrs, :number, 0)
+  end
+
+  defp get_highest_number(show_id) do
+    query =
+      from e in Episode,
+        select: max(e.number),
+        where: [show_id: ^show_id]
+
+    Repo.one(query) || 0
   end
 
   @doc """

--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -10,6 +10,7 @@ defmodule Radiator.Podcast.Episode do
 
   schema "episodes" do
     field :title, :string
+    field :number, :integer
     belongs_to :show, Show
     timestamps(type: :utc_datetime)
   end

--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -18,7 +18,7 @@ defmodule Radiator.Podcast.Episode do
   @doc false
   def changeset(episode, attrs) do
     episode
-    |> cast(attrs, [:title, :show_id])
-    |> validate_required([:title, :show_id])
+    |> cast(attrs, [:title, :show_id, :number])
+    |> validate_required([:title, :show_id, :number])
   end
 end

--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -1,7 +1,7 @@
 defmodule Radiator.Podcast.Episode do
   @moduledoc """
     Represents the Episode model.
-    TODO: Episodes should be numbered and ordered inside a show.
+    Episodes are numbered inside a show.
   """
   use Ecto.Schema
   import Ecto.Changeset

--- a/lib/radiator_web/controllers/api/outline_controller.ex
+++ b/lib/radiator_web/controllers/api/outline_controller.ex
@@ -9,6 +9,9 @@ defmodule RadiatorWeb.Api.OutlineController do
       token
       |> decode_token()
       |> get_user_by_token()
+      # show will be send in request from frontend (show_id)
+      # fetch wanted/current episode for show
+
       |> create_node(content)
       |> get_response()
 

--- a/priv/repo/migrations/20231216182723_add_outline_reference_to_episode.exs
+++ b/priv/repo/migrations/20231216182723_add_outline_reference_to_episode.exs
@@ -1,0 +1,9 @@
+defmodule Radiator.Repo.Migrations.AddOutlineReferenceToEpisode do
+  use Ecto.Migration
+
+  def change do
+    alter table(:outline_nodes) do
+      add :episode_id, references(:episodes, on_delete: :nothing)
+    end
+  end
+end

--- a/priv/repo/migrations/20231223124852_add_number_to_episodes.exs
+++ b/priv/repo/migrations/20231223124852_add_number_to_episodes.exs
@@ -1,0 +1,9 @@
+defmodule Radiator.Repo.Migrations.AddNumberToEpisodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:episodes) do
+      add :number, :integer
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,12 +10,6 @@ alias Radiator.{Accounts, Outline, Podcast}
 {:ok, _user_jim} =
   Accounts.register_user(%{email: "jim@radiator.de", password: "supersupersecret"})
 
-{:ok, _node} =
-  Outline.create_node(%{content: "This is my first node"})
-
-{:ok, _node} =
-  Outline.create_node(%{content: "Second node"})
-
 {:ok, network} =
   Podcast.create_network(%{title: "Podcast network"})
 
@@ -28,5 +22,11 @@ alias Radiator.{Accounts, Outline, Podcast}
 {:ok, _episode} =
   Podcast.create_episode(%{title: "past episode", show_id: show.id})
 
-{:ok, _episode} =
+{:ok, current_episode} =
   Podcast.create_episode(%{title: "current episode", show_id: show.id})
+
+{:ok, _node} =
+  Outline.create_node(%{content: "This is my first node", episode_id: current_episode.id})
+
+{:ok, _node} =
+  Outline.create_node(%{content: "Second node", episode_id: current_episode.id})

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -7,6 +7,7 @@ defmodule Radiator.OutlineTest do
     alias Radiator.Outline.Node
 
     import Radiator.OutlineFixtures
+    alias Radiator.PodcastFixtures
 
     @invalid_attrs %{content: nil}
 
@@ -21,22 +22,25 @@ defmodule Radiator.OutlineTest do
     end
 
     test "create_node/1 with valid data creates a node" do
-      valid_attrs = %{content: "some content"}
+      episode = PodcastFixtures.episode_fixture()
+      valid_attrs = %{content: "some content", episode_id: episode.id}
 
       assert {:ok, %Node{} = node} = Outline.create_node(valid_attrs)
       assert node.content == "some content"
     end
 
     test "create_node/1 trims whitespace from content" do
-      valid_attrs = %{content: "  some content  "}
+      episode = PodcastFixtures.episode_fixture()
+      valid_attrs = %{content: "  some content  ", episode_id: episode.id}
 
       assert {:ok, %Node{} = node} = Outline.create_node(valid_attrs)
       assert node.content == "some content"
     end
 
     test "create_node/1 can have a creator" do
+      episode = PodcastFixtures.episode_fixture()
       user = %{id: 2}
-      valid_attrs = %{content: "some content"}
+      valid_attrs = %{content: "some content", episode_id: episode.id}
 
       assert {:ok, %Node{} = node} = Outline.create_node(valid_attrs, user)
       assert node.content == "some content"

--- a/test/radiator/podcast_test.exs
+++ b/test/radiator/podcast_test.exs
@@ -187,5 +187,28 @@ defmodule Radiator.PodcastTest do
       episode = episode_fixture()
       assert %Ecto.Changeset{} = Podcast.change_episode(episode)
     end
+
+    test "get_current_episode_for_show/1 returns nil when no show has been given" do
+      assert nil == Podcast.get_current_episode_for_show(nil)
+    end
+
+    test "get_current_episode_for_show/1 returns nil when no episode for show exists" do
+      show = show_fixture()
+      assert nil == Podcast.get_current_episode_for_show(show.id)
+    end
+
+    test "get_current_episode_for_show/1 returns episdoe for show" do
+      episode = episode_fixture()
+      assert episode == Podcast.get_current_episode_for_show(episode.show_id)
+    end
+
+    test "get_current_episode_for_show/1 returns the episode with the highest number" do
+      show = show_fixture()
+      # create new before old to ensure that the highest number is returned
+      # and not just the newest
+      episode_new = episode_fixture(number: 23, show_id: show.id)
+      _episode_old = episode_fixture(number: 22, show_id: show.id)
+      assert episode_new == Podcast.get_current_episode_for_show(show.id)
+    end
   end
 end

--- a/test/radiator/podcast_test.exs
+++ b/test/radiator/podcast_test.exs
@@ -132,6 +132,31 @@ defmodule Radiator.PodcastTest do
       assert episode.show_id == show.id
     end
 
+    test "create_episode/1 sets for first episode number 1" do
+      episode_attrs = %{title: "a new episode", show_id: show_fixture().id}
+
+      {:ok, %Episode{} = episode} = Podcast.create_episode(episode_attrs)
+      assert episode.number > 0
+    end
+
+    test "create_episode/1 finds the next highest number " do
+      show = show_fixture()
+      episode_fixture(show_id: show.id, number: 23)
+      episode_attrs = %{title: "my new episode", show_id: show.id}
+
+      {:ok, %Episode{} = episode} = Podcast.create_episode(episode_attrs)
+      assert episode.number == 24
+    end
+
+    test "create_episode/1 can be set explict" do
+      show = show_fixture()
+      episode_fixture(show_id: show.id, number: 2)
+      episode_attrs = %{title: "my new episode", number: 5, show_id: show.id}
+
+      {:ok, %Episode{} = episode} = Podcast.create_episode(episode_attrs)
+      assert episode.number == 5
+    end
+
     test "create_episode/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Podcast.create_episode(@invalid_attrs)
     end

--- a/test/support/fixtures/outline_fixtures.ex
+++ b/test/support/fixtures/outline_fixtures.ex
@@ -3,16 +3,20 @@ defmodule Radiator.OutlineFixtures do
   This module defines test helpers for creating
   entities via the `Radiator.Outline` context.
   """
-
+  alias Radiator.PodcastFixtures
   @doc """
   Generate a node.
   """
   def node_fixture(attrs \\ %{}) do
+    episode = PodcastFixtures.episode_fixture()
+
     {:ok, node} =
       attrs
-      |> Enum.into(%{content: "some content"})
+      |> Enum.into(%{
+        content: "some content",
+        episode_id: episode.id
+      })
       |> Radiator.Outline.create_node()
-
     node
   end
 end

--- a/test/support/fixtures/outline_fixtures.ex
+++ b/test/support/fixtures/outline_fixtures.ex
@@ -4,6 +4,7 @@ defmodule Radiator.OutlineFixtures do
   entities via the `Radiator.Outline` context.
   """
   alias Radiator.PodcastFixtures
+
   @doc """
   Generate a node.
   """
@@ -17,6 +18,7 @@ defmodule Radiator.OutlineFixtures do
         episode_id: episode.id
       })
       |> Radiator.Outline.create_node()
+
     node
   end
 end


### PR DESCRIPTION
Connect nodes to episodes. This is a required argument. No node should be be dangling since they would never be shown. 

The controller expects a show_id for a node to be created. In order to connect the node the a episode we need do find a episode. In the near future this will be the one in draft mode, or even the one stored in a user preference. 
Currently it just returns the episode with the highest number. And episodes have a number now. 