### PR TITLE
Refactor/node repo

### DIFF
--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -108,6 +108,25 @@ defmodule Radiator.Outline do
   end
 
   @doc """
+  Moves a nodes to another parent.
+
+  ## Examples
+
+      iex> move_node(node, %Node{uuid: new_parent_id})
+      {:ok, %Node{}}
+
+      iex> move_node(node, nil)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def move_node(%Node{} = node, %Node{} = parent_node) do
+    node
+    |> Node.move_changeset(parent_node)
+    |> Repo.update()
+    |> broadcast_node_action(:update)
+  end
+
+  @doc """
   Deletes a node.
 
   ## Examples

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -77,6 +77,7 @@ defmodule Radiator.Outline do
     node_tree_initial_query =
       Node
       |> where([n], is_nil(n.parent_id))
+      |> where([n], n.episode_id == ^episode_id)
 
     node_tree_recursion_query =
       Node

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -76,33 +76,33 @@ defmodule Radiator.Outline do
   """
   def create_node(attrs \\ %{}) do
     %Node{}
-    |> Node.changeset(attrs)
+    |> Node.insert_changeset(attrs)
     |> Repo.insert()
     |> broadcast_node_action(:insert)
   end
 
   def create_node(attrs, %{id: id}) do
     %Node{creator_id: id}
-    |> Node.changeset(attrs)
+    |> Node.insert_changeset(attrs)
     |> Repo.insert()
     |> broadcast_node_action(:insert)
   end
 
   @doc """
-  Updates a node.
+  Updates a nodes content.
 
   ## Examples
 
-      iex> update_node(node, %{field: new_value})
+      iex> update_node_content(node, %{content: new_value})
       {:ok, %Node{}}
 
-      iex> update_node(node, %{field: bad_value})
+      iex> update_node_content(node, %{content: nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_node(%Node{} = node, attrs) do
+  def update_node_content(%Node{} = node, attrs) do
     node
-    |> Node.changeset(attrs)
+    |> Node.update_content_changeset(attrs)
     |> Repo.update()
     |> broadcast_node_action(:update)
   end
@@ -123,19 +123,6 @@ defmodule Radiator.Outline do
     node
     |> Repo.delete()
     |> broadcast_node_action(:delete)
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking node changes.
-
-  ## Examples
-
-      iex> change_node(node)
-      %Ecto.Changeset{data: %Node{}}
-
-  """
-  def change_node(%Node{} = node, attrs \\ %{}) do
-    Node.changeset(node, attrs)
   end
 
   defp broadcast_node_action({:ok, node}, action) do

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -63,6 +63,39 @@ defmodule Radiator.Outline do
   end
 
   @doc """
+  Gets all nodes of an episode as a tree.
+
+  ## Examples
+
+      iex> get_node_tree(123)
+      [%Node{}, %Node{}, ..]
+  """
+  #  episode_id = 2
+  #  Radiator.Outline.get_node_tree(episode_id)
+  def get_node_tree(episode_id) do
+
+    node_tree_initial_query =
+      Node
+      |> where([n], is_nil(n.parent_id))
+
+    node_tree_recursion_query =
+      Node
+      |> join(:inner, [n], nd in "node_tree", on: n.parent_id == nd.uuid)
+
+    node_tree_query =
+      node_tree_initial_query
+      |> union_all(^node_tree_recursion_query)
+
+    tree =
+      Node
+      |> recursive_ctes(true)
+      |> with_cte("node_tree", as: ^node_tree_query)
+      |> Repo.all()
+
+    {:ok, tree}
+  end
+
+  @doc """
   Creates a node.
 
   ## Examples

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -10,6 +10,7 @@ defmodule Radiator.Outline.Node do
   @derive {Jason.Encoder, only: [:uuid, :content, :creator_id, :parent_id, :prev_id]}
 
   @primary_key {:uuid, :binary_id, autogenerate: true}
+
   schema "outline_nodes" do
     field :content, :string
     field :creator_id, :integer
@@ -21,25 +22,38 @@ defmodule Radiator.Outline.Node do
     timestamps(type: :utc_datetime)
   end
 
-  @required_fields [
-    :content,
-    :episode_id
-  ]
-
-  @optional_fields [
-    :creator_id,
-    :parent_id,
-    :prev_id
-  ]
-
-  @all_fields @optional_fields ++ @required_fields
-
-  @doc false
-  def changeset(node, attrs) do
+  @doc """
+  A changeset for inserting a new node
+  Work in progress. Since we currently ignore the tree structure, there is
+  no concept for a root node.
+  Also questionable wether a node really needs a content from beginning. So probably a root
+  doesnt have a content
+  Another issue might be we need to create the uuid upfront and pass it here
+  """
+  def insert_changeset(node, attributes) do
     node
-    |> cast(attrs, @all_fields)
+    |> cast(attributes, [:content, :episode_id, :creator_id, :parent_id, :prev_id])
     |> update_change(:content, &trim/1)
-    |> validate_required(@required_fields)
+    |> validate_required([:content, :episode_id])
+  end
+
+  @doc """
+  Changeset for moving a node
+  Only the parent_id is allowed and expected to be changed
+  """
+  def move_changeset(node, attrs) do
+    node
+    |> cast(attrs, [:parent_id])
+  end
+
+  @doc """
+  Changeset for updating the content of a node
+  """
+  def update_content_changeset(node, attrs) do
+    node
+    |> cast(attrs, [:content])
+    |> update_change(:content, &trim/1)
+    |> validate_required([:content])
   end
 
   defp trim(content) when is_binary(content), do: String.trim(content)

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -16,6 +16,7 @@ defmodule Radiator.Outline.Node do
     field :creator_id, :integer
     field :parent_id, Ecto.UUID
     field :prev_id, Ecto.UUID
+    field :level, :integer, virtual: true
 
     belongs_to :episode, Episode
 

--- a/lib/radiator_web/live/episode_live/index.ex
+++ b/lib/radiator_web/live/episode_live/index.ex
@@ -64,7 +64,7 @@ defmodule RadiatorWeb.EpisodeLive.Index do
 
     case Outline.get_node(uuid) do
       nil -> nil
-      node -> Outline.update_node(node, attrs)
+      node -> Outline.update_node_content(node, attrs)
     end
 
     socket

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -19,7 +19,7 @@ alias Radiator.{Accounts, Outline, Podcast}
 {:ok, show} =
   Podcast.create_show(%{title: "Tech Weekly", network_id: network.id})
 
-{:ok, _episode} =
+{:ok, past_episode} =
   Podcast.create_episode(%{title: "past episode", show_id: show.id})
 
 {:ok, current_episode} =
@@ -60,3 +60,7 @@ alias Radiator.{Accounts, Outline, Podcast}
     episode_id: current_episode.id,
     prev_id: node211.uuid
   })
+
+
+  {:ok, past_parent_node} =
+    Outline.create_node(%{content: "Old Content", episode_id: past_episode.id})

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -121,14 +121,14 @@ defmodule Radiator.OutlineTest do
     setup :complex_node_fixture
 
     test "returns all nodes from a episode", %{
-      node_1: node_1,
-      node_2: node_2,
-      node_3: node_3,
-      node_4: node_4,
-      node_5: node_5,
-      node_6: node_6,
-      nested_node_1: nested_node_1,
-      nested_node_2: nested_node_2,
+      # node_1: node_1,
+      # node_2: node_2,
+      # node_3: node_3,
+      # node_4: node_4,
+      # node_5: node_5,
+      # node_6: node_6,
+      # nested_node_1: nested_node_1,
+      # nested_node_2: nested_node_2,
       parent: parent
     } do
       episode_id = parent.episode_id
@@ -139,12 +139,26 @@ defmodule Radiator.OutlineTest do
         |> where([n], n.episode_id == ^episode_id)
         |> Repo.all()
       assert Enum.count(tree) == Enum.count(all_nodes)
+      Enum.each(tree, fn node ->
+        assert node == List.first(Enum.filter(all_nodes, fn n -> n.uuid == node.uuid end))
+      end)
     end
+
+    test "does not return a node not in this episode", %{
+     parent: parent
+    } do
+      episode_id = parent.episode_id
+      other_node = node_fixture(parent_id: nil, prev_id: nil, content: "other content")
+      assert other_node.episode_id != episode_id
+      {:ok, tree} = Outline.get_node_tree(episode_id)
+      assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == nil
+    end
+
   end
 
   defp complex_node_fixture(_) do
     episode = PodcastFixtures.episode_fixture()
-    parent = node_fixture(episode_id: episode.id)
+    parent = node_fixture(episode_id: episode.id, parent_id: nil, prev_id: nil)
     node_1 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: nil)
     node_2 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_1.uuid)
     node_3 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_2.uuid)

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -51,17 +51,17 @@ defmodule Radiator.OutlineTest do
       assert {:error, %Ecto.Changeset{}} = Outline.create_node(@invalid_attrs)
     end
 
-    test "update_node/2 with valid data updates the node" do
+    test "update_node_content/2 with valid data updates the node" do
       node = node_fixture()
       update_attrs = %{content: "some updated content"}
 
-      assert {:ok, %Node{} = node} = Outline.update_node(node, update_attrs)
+      assert {:ok, %Node{} = node} = Outline.update_node_content(node, update_attrs)
       assert node.content == "some updated content"
     end
 
-    test "update_node/2 with invalid data returns error changeset" do
+    test "update_node_content/2 with invalid data returns error changeset" do
       node = node_fixture()
-      assert {:error, %Ecto.Changeset{}} = Outline.update_node(node, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Outline.update_node_content(node, @invalid_attrs)
       assert node == Outline.get_node!(node.uuid)
     end
 
@@ -69,11 +69,6 @@ defmodule Radiator.OutlineTest do
       node = node_fixture()
       assert {:ok, %Node{}} = Outline.delete_node(node)
       assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(node.uuid) end
-    end
-
-    test "change_node/1 returns a node changeset" do
-      node = node_fixture()
-      assert %Ecto.Changeset{} = Outline.change_node(node)
     end
   end
 end

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -140,7 +140,7 @@ defmodule Radiator.OutlineTest do
         |> Repo.all()
       assert Enum.count(tree) == Enum.count(all_nodes)
       Enum.each(tree, fn node ->
-        assert node == List.first(Enum.filter(all_nodes, fn n -> n.uuid == node.uuid end))
+        assert node.uuid == List.first(Enum.filter(all_nodes, fn n -> n.uuid == node.uuid end)).uuid
       end)
     end
 
@@ -151,9 +151,8 @@ defmodule Radiator.OutlineTest do
       other_node = node_fixture(parent_id: nil, prev_id: nil, content: "other content")
       assert other_node.episode_id != episode_id
       {:ok, tree} = Outline.get_node_tree(episode_id)
-      assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == nil
+      assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == []
     end
-
   end
 
   defp complex_node_fixture(_) do

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -98,4 +98,49 @@ defmodule Radiator.OutlineTest do
       assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(node.uuid) end
     end
   end
+
+  describe "get_node_tree/1" do
+    test "returns all nodes from a episode", %{
+      node_1: node_1,
+      node_2: node_2,
+      node_3: node_3,
+      node_4: node_4,
+      node_5: node_5,
+      node_6: node_6,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2,
+      parent: parent
+    } do
+      assert {:ok, tree}} = Outline.get_node_tree(parent.episode_id)
+      assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(node.uuid) end
+      assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(child.uuid) end
+      assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(grandchild.uuid) end
+    end
+  end
+
+  defp complex_node_fixture(_) do
+    episode = PodcastFixtures.episode_fixture()
+    parent = node_fixture(episode_id: episode.id)
+    node_1 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: nil)
+    node_2 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_1.uuid)
+    node_3 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_2.uuid)
+    node_4 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_3.uuid)
+    node_5 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_4.uuid)
+    node_6 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_5.uuid)
+
+    nested_node_1 = node_fixture(episode_id: episode.id, parent_id: node_3.uuid, prev_id: nil)
+    nested_node_2 = node_fixture(episode_id: episode.id, parent_id: node_3.uuid, prev_id: nested_node_1.uuid)
+
+    %{
+      node_1: node_1,
+      node_2: node_2,
+      node_3: node_3,
+      node_4: node_4,
+      node_5: node_5,
+      node_6: node_6,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2,
+      parent: parent
+    }
+  end
 end


### PR DESCRIPTION
In order to migrate to a event based architecture we need more usecase specific repo access.  
Main change here is to split the update into an`update_node_content` and`move_node` call . Both have different changesets and validations.  