### PR TITLE
Feature/insert node into tree

### DIFF
--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -90,6 +90,88 @@ defmodule Radiator.Outline do
   end
 
   @doc """
+  Gets all nodes of an episode as a tree.
+  Uses a Common Table Expression (CTE) to recursively query the database.
+  Sets the level of each node in the tree. Level 0 are the root nodes (without a parent)
+  Returns a list with all nodes of the episode sorted by the level.
+  ## Examples
+
+      iex> get_node_tree(123)
+      [%Node{}, %Node{}, ..]
+
+  SQL:
+  WITH RECURSIVE node_tree AS (
+        SELECT uuid, content, parent_id, prev_id, 0 AS level
+        FROM outline_nodes
+        WHERE episode_id = ?::integer and parent_id is NULL
+     UNION ALL
+        SELECT outline_nodes.uuid, outline_nodes.content, outline_nodes.parent_id, outline_nodes.prev_id, node_tree.level + 1
+        FROM outline_nodes
+           JOIN node_tree ON outline_nodes.parent_id = node_tree.uuid
+  )
+  SELECT * FROM node_tree;
+  """
+  def get_node_tree(episode_id) do
+    node_tree_initial_query =
+      Node
+      |> where([n], is_nil(n.parent_id))
+      |> where([n], n.episode_id == ^episode_id)
+      |> select([n], %{
+        uuid: n.uuid,
+        content: n.content,
+        parent_id: n.parent_id,
+        prev_id: n.prev_id,
+        level: 0
+      })
+
+    node_tree_recursion_query =
+      from outline_node in "outline_nodes",
+        join: node_tree in "node_tree",
+        on: outline_node.parent_id == node_tree.uuid,
+        select: [
+          outline_node.uuid,
+          outline_node.content,
+          outline_node.parent_id,
+          outline_node.prev_id,
+          node_tree.level + 1
+        ]
+
+    node_tree_query =
+      node_tree_initial_query
+      |> union_all(^node_tree_recursion_query)
+
+    tree =
+      "node_tree"
+      |> recursive_ctes(true)
+      |> with_cte("node_tree", as: ^node_tree_query)
+      |> select([n], %{
+        uuid: n.uuid,
+        content: n.content,
+        parent_id: n.parent_id,
+        prev_id: n.prev_id,
+        level: n.level
+      })
+      |> Repo.all()
+      |> Enum.map(fn %{
+                       uuid: uuid,
+                       content: content,
+                       parent_id: parent_id,
+                       prev_id: prev_id,
+                       level: level
+                     } ->
+        %Node{
+          uuid: binaray_uuid_to_ecto_uuid(uuid),
+          content: content,
+          parent_id: binaray_uuid_to_ecto_uuid(parent_id),
+          prev_id: binaray_uuid_to_ecto_uuid(prev_id),
+          level: level
+        }
+      end)
+
+    {:ok, tree}
+  end
+
+  @doc """
   Creates a node.
 
   ## Examples
@@ -106,12 +188,6 @@ defmodule Radiator.Outline do
     |> Node.insert_changeset(attrs)
     |> Repo.insert()
     |> Notify.broadcast_node_action(:insert, socket_id)
-  end
-
-  def create_node(attrs, %{id: id}) do
-    %Node{creator_id: id}
-    |> Node.insert_changeset(attrs)
-    |> Repo.insert()
   end
 
   @doc """
@@ -148,5 +224,11 @@ defmodule Radiator.Outline do
   def delete_node(%Node{} = node) do
     node
     |> Repo.delete()
+  end
+
+  defp binaray_uuid_to_ecto_uuid(nil), do: nil
+
+  defp binaray_uuid_to_ecto_uuid(uuid) do
+    Ecto.UUID.load!(uuid)
   end
 end

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -15,12 +15,6 @@ defmodule Radiator.Outline do
     |> Notify.broadcast_node_action(:insert, socket_id)
   end
 
-  def update(%Node{} = node, attrs, socket_id \\ nil) do
-    node
-    |> update_node(attrs)
-    |> Notify.broadcast_node_action(:update, socket_id)
-  end
-
   def delete(%Node{} = node, socket_id \\ nil) do
     node
     |> delete_node()
@@ -107,28 +101,36 @@ defmodule Radiator.Outline do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_node(attrs \\ %{}) do
+  def create_node(attrs \\ %{}, socket_id \\ nil) do
     %Node{}
-    |> Node.changeset(attrs)
+    |> Node.insert_changeset(attrs)
+    |> Repo.insert()
+    |> Notify.broadcast_node_action(:insert, socket_id)
+  end
+
+  def create_node(attrs, %{id: id}) do
+    %Node{creator_id: id}
+    |> Node.insert_changeset(attrs)
     |> Repo.insert()
   end
 
   @doc """
-  Updates a node.
+  Updates a nodes content.
 
   ## Examples
 
-      iex> update_node(node, %{field: new_value})
+      iex> update_node_content(node, %{content: new_value})
       {:ok, %Node{}}
 
-      iex> update_node(node, %{field: bad_value})
+      iex> update_node_content(node, %{content: nil})
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_node(%Node{} = node, attrs) do
+  def update_node_content(%Node{} = node, attrs, socket_id \\ nil) do
     node
-    |> Node.changeset(attrs)
+    |> Node.update_content_changeset(attrs)
     |> Repo.update()
+    |> Notify.broadcast_node_action(:update, socket_id)
   end
 
   @doc """
@@ -146,18 +148,5 @@ defmodule Radiator.Outline do
   def delete_node(%Node{} = node) do
     node
     |> Repo.delete()
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking node changes.
-
-  ## Examples
-
-      iex> change_node(node)
-      %Ecto.Changeset{data: %Node{}}
-
-  """
-  def change_node(%Node{} = node, attrs \\ %{}) do
-    Node.changeset(node, attrs)
   end
 end

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -47,6 +47,11 @@ defmodule Radiator.Outline.Node do
     |> validate_required([:content])
   end
 
+  def move_node_changeset(node, attrs) do
+    node
+    |> cast(attrs, [:parent_id, :prev_id])
+  end
+
   defp trim(content) when is_binary(content), do: String.trim(content)
   defp trim(content), do: content
 end

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -10,12 +10,12 @@ defmodule Radiator.Outline.Node do
   @derive {Jason.Encoder, only: [:uuid, :content, :creator_id, :parent_id, :prev_id]}
 
   @primary_key {:uuid, :binary_id, autogenerate: true}
-
   schema "outline_nodes" do
     field :content, :string
     field :creator_id, :integer
     field :parent_id, Ecto.UUID
     field :prev_id, Ecto.UUID
+    field :level, :integer, virtual: true
 
     belongs_to :episode, Episode
 
@@ -35,15 +35,6 @@ defmodule Radiator.Outline.Node do
     |> cast(attributes, [:content, :episode_id, :creator_id, :parent_id, :prev_id])
     |> update_change(:content, &trim/1)
     |> validate_required([:content, :episode_id])
-  end
-
-  @doc """
-  Changeset for moving a node
-  Only the parent_id is allowed and expected to be changed
-  """
-  def move_changeset(node, attrs) do
-    node
-    |> cast(attrs, [:parent_id])
   end
 
   @doc """

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -10,6 +10,7 @@ defmodule Radiator.Outline.Node do
   @derive {Jason.Encoder, only: [:uuid, :content, :creator_id, :parent_id, :prev_id]}
 
   @primary_key {:uuid, :binary_id, autogenerate: true}
+
   schema "outline_nodes" do
     field :content, :string
     field :creator_id, :integer
@@ -21,25 +22,38 @@ defmodule Radiator.Outline.Node do
     timestamps(type: :utc_datetime)
   end
 
-  @required_fields [
-    :episode_id
-  ]
-
-  @optional_fields [
-    :content,
-    :creator_id,
-    :parent_id,
-    :prev_id
-  ]
-
-  @all_fields @optional_fields ++ @required_fields
-
-  @doc false
-  def changeset(node, attrs) do
+  @doc """
+  A changeset for inserting a new node
+  Work in progress. Since we currently ignore the tree structure, there is
+  no concept for a root node.
+  Also questionable wether a node really needs a content from beginning. So probably a root
+  doesnt have a content
+  Another issue might be we need to create the uuid upfront and pass it here
+  """
+  def insert_changeset(node, attributes) do
     node
-    |> cast(attrs, @all_fields)
+    |> cast(attributes, [:content, :episode_id, :creator_id, :parent_id, :prev_id])
     |> update_change(:content, &trim/1)
-    |> validate_required(@required_fields)
+    |> validate_required([:content, :episode_id])
+  end
+
+  @doc """
+  Changeset for moving a node
+  Only the parent_id is allowed and expected to be changed
+  """
+  def move_changeset(node, attrs) do
+    node
+    |> cast(attrs, [:parent_id])
+  end
+
+  @doc """
+  Changeset for updating the content of a node
+  """
+  def update_content_changeset(node, attrs) do
+    node
+    |> cast(attrs, [:content])
+    |> update_change(:content, &trim/1)
+    |> validate_required([:content])
   end
 
   defp trim(content) when is_binary(content), do: String.trim(content)

--- a/lib/radiator_web/live/episode_live/index.ex
+++ b/lib/radiator_web/live/episode_live/index.ex
@@ -61,7 +61,7 @@ defmodule RadiatorWeb.EpisodeLive.Index do
 
     case Outline.get_node(uuid) do
       nil -> nil
-      node -> Outline.update(node, attrs, socket.id)
+      node -> Outline.update_node_content(node, attrs, socket.id)
     end
 
     socket

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -19,7 +19,7 @@ alias Radiator.{Accounts, Outline, Podcast}
 {:ok, show} =
   Podcast.create_show(%{title: "Tech Weekly", network_id: network.id})
 
-{:ok, _episode} =
+{:ok, past_episode} =
   Podcast.create_episode(%{title: "past episode", show_id: show.id})
 
 {:ok, current_episode} =
@@ -60,3 +60,6 @@ alias Radiator.{Accounts, Outline, Podcast}
     episode_id: current_episode.id,
     prev_id: node211.uuid
   })
+
+{:ok, past_parent_node} =
+  Outline.create_node(%{content: "Old Content", episode_id: past_episode.id})

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -2,16 +2,17 @@ defmodule Radiator.OutlineTest do
   use Radiator.DataCase
 
   alias Radiator.Outline
+  alias Radiator.Outline.Node
+  alias Radiator.PodcastFixtures
+  alias Radiator.Repo
 
-  describe "outline_nodes" do
-    alias Radiator.Outline.Node
+  import Radiator.OutlineFixtures
+  import Ecto.Query, warn: false
 
-    import Radiator.OutlineFixtures
-    alias Radiator.PodcastFixtures
+  @invalid_attrs %{episode_id: nil}
 
-    @invalid_attrs %{episode_id: nil}
-
-    test "list_nodes/0 returns all nodes" do
+  describe "list_nodes/0" do
+    test "returns all nodes" do
       node1 = node_fixture()
       node2 = node_fixture()
 
@@ -25,13 +26,17 @@ defmodule Radiator.OutlineTest do
       assert Outline.list_nodes_by_episode(node1.episode_id) == [node1]
       assert Outline.list_nodes_by_episode(node2.episode_id) == [node2]
     end
+  end
 
-    test "get_node!/1 returns the node with given id" do
+  describe "get_node!/1" do
+    test "returns the node with given id" do
       node = node_fixture()
       assert Outline.get_node!(node.uuid) == node
     end
+  end
 
-    test "create_node/1 with valid data creates a node" do
+  describe "create_node/1" do
+    test "with valid data creates a node" do
       episode = PodcastFixtures.episode_fixture()
       valid_attrs = %{content: "some content", episode_id: episode.id}
 
@@ -39,7 +44,7 @@ defmodule Radiator.OutlineTest do
       assert node.content == "some content"
     end
 
-    test "create_node/1 trims whitespace from content" do
+    test "trims whitespace from content" do
       episode = PodcastFixtures.episode_fixture()
       valid_attrs = %{content: "  some content  ", episode_id: episode.id}
 
@@ -47,11 +52,23 @@ defmodule Radiator.OutlineTest do
       assert node.content == "some content"
     end
 
-    test "create_node/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Outline.create_node(@invalid_attrs)
+    test "can have a creator" do
+      episode = PodcastFixtures.episode_fixture()
+      user = %{id: 2}
+      valid_attrs = %{content: "some content", episode_id: episode.id, creator_id: user.id}
+
+      assert {:ok, %Node{} = node} = Outline.create_node(valid_attrs, user)
+      assert node.content == "some content"
+      assert node.creator_id == user.id
     end
 
-    test "update_node_content/2 with valid data updates the node" do
+    test "with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Outline.create_node(@invalid_attrs)
+    end
+  end
+
+  describe "update_node_content/2" do
+    test "with valid data updates the node" do
       node = node_fixture()
       update_attrs = %{content: "some updated content"}
 
@@ -59,16 +76,92 @@ defmodule Radiator.OutlineTest do
       assert node.content == "some updated content"
     end
 
-    test "update_node_content/2 with invalid data returns error changeset" do
+    test "with invalid data returns error changeset" do
       node = node_fixture()
       assert {:error, %Ecto.Changeset{}} = Outline.update_node_content(node, %{content: nil})
       assert node == Outline.get_node!(node.uuid)
     end
+  end
 
-    test "delete_node/1 deletes the node" do
+  describe "delete_node/1" do
+    test "deletes the node" do
       node = node_fixture()
       assert {:ok, %Node{}} = Outline.delete_node(node)
       assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(node.uuid) end
     end
+  end
+
+  describe "get_node_tree/1" do
+    setup :complex_node_fixture
+
+    test "returns all nodes from a episode", %{parent: parent} do
+      episode_id = parent.episode_id
+      assert {:ok, tree} = Outline.get_node_tree(episode_id)
+
+      all_nodes =
+        Node
+        |> where([n], n.episode_id == ^episode_id)
+        |> Repo.all()
+
+      assert Enum.count(tree) == Enum.count(all_nodes)
+
+      Enum.each(tree, fn node ->
+        assert node.uuid ==
+                 List.first(Enum.filter(all_nodes, fn n -> n.uuid == node.uuid end)).uuid
+      end)
+    end
+
+    test "does not return a node from another episode", %{
+      parent: parent
+    } do
+      episode_id = parent.episode_id
+      other_node = node_fixture(parent_id: nil, prev_id: nil, content: "other content")
+      assert other_node.episode_id != episode_id
+      {:ok, tree} = Outline.get_node_tree(episode_id)
+      assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == []
+    end
+
+    test "returns nodes sorted by level", %{parent: parent} do
+      episode_id = parent.episode_id
+      {:ok, tree} = Outline.get_node_tree(episode_id)
+
+      Enum.reduce(tree, 0, fn node, current_level ->
+        if node.parent_id != nil do
+          parent = Enum.find(tree, fn n -> n.uuid == node.parent_id end)
+          assert parent.level + 1 == node.level
+        end
+
+        assert node.level >= current_level
+        node.level
+      end)
+    end
+  end
+
+  defp complex_node_fixture(_) do
+    episode = PodcastFixtures.episode_fixture()
+    parent = node_fixture(episode_id: episode.id, parent_id: nil, prev_id: nil)
+    node_1 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: nil)
+    node_2 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_1.uuid)
+    node_3 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_2.uuid)
+    node_4 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_3.uuid)
+    node_5 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_4.uuid)
+    node_6 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_5.uuid)
+
+    nested_node_1 = node_fixture(episode_id: episode.id, parent_id: node_3.uuid, prev_id: nil)
+
+    nested_node_2 =
+      node_fixture(episode_id: episode.id, parent_id: node_3.uuid, prev_id: nested_node_1.uuid)
+
+    %{
+      node_1: node_1,
+      node_2: node_2,
+      node_3: node_3,
+      node_4: node_4,
+      node_5: node_5,
+      node_6: node_6,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2,
+      parent: parent
+    }
   end
 end

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -69,7 +69,7 @@ defmodule Radiator.OutlineTest do
   describe "update_node_content/2" do
     test "with valid data updates the node" do
       node = node_fixture()
-      update_attrs = %{content: "some updated content"}
+      update_attrs = %{"content" => "some updated content"}
 
       assert {:ok, %Node{} = node} = Outline.update_node_content(node, update_attrs)
       assert node.content == "some updated content"
@@ -77,7 +77,7 @@ defmodule Radiator.OutlineTest do
 
     test "with invalid data returns error changeset" do
       node = node_fixture()
-      assert {:error, %Ecto.Changeset{}} = Outline.update_node_content(node, %{content: nil})
+      assert {:error, %Ecto.Changeset{}} = Outline.update_node_content(node, %{"content" => nil})
       assert node == Outline.get_node!(node.uuid)
     end
   end
@@ -110,6 +110,179 @@ defmodule Radiator.OutlineTest do
     end
   end
 
+  describe "insert_node/1" do
+    setup :complex_node_fixture
+
+    test "creates a new node in the tree", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1
+    } do
+      count_nodes = Outline.count_nodes_by_episode(node_3.episode_id)
+
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_node" => node_3.uuid,
+        "prev_node" => nested_node_1.uuid
+      }
+
+      Outline.insert_node(node_attrs)
+      new_count_nodes = Outline.count_nodes_by_episode(node_3.episode_id)
+      assert new_count_nodes == count_nodes + 1
+    end
+
+    test "the parent gets set", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1
+    } do
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_node" => node_3.uuid,
+        "prev_node" => nested_node_1.uuid
+      }
+
+      {:ok, new_node} = Outline.insert_node(node_attrs)
+      assert new_node.parent_id == node_3.uuid
+    end
+
+    test "the prev gets set", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1
+    } do
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_node" => node_3.uuid,
+        "prev_node" => nested_node_1.uuid
+      }
+
+      {:ok, new_node} = Outline.insert_node(node_attrs)
+      assert new_node.prev_id == nested_node_1.uuid
+    end
+
+    test "all nodes in same level are correctly connected", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2
+    } do
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_node" => node_3.uuid,
+        "prev_node" => nested_node_1.uuid
+      }
+
+      {:ok, new_node} = Outline.insert_node(node_attrs)
+
+      assert Outline.get_node!(nested_node_2.uuid).prev_id == new_node.uuid
+      assert new_node.prev_id == nested_node_1.uuid
+      assert Outline.get_node!(nested_node_1.uuid).prev_id == nil
+    end
+
+    test "inserted node can be inserted at the end", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2
+    } do
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_node" => node_3.uuid,
+        "prev_node" => nested_node_2.uuid
+      }
+
+      {:ok, new_node} = Outline.insert_node(node_attrs)
+
+      assert Outline.get_node!(nested_node_2.uuid).prev_id == nested_node_1.uuid
+      assert new_node.prev_id == nested_node_2.uuid
+      assert Outline.get_node!(nested_node_1.uuid).prev_id == nil
+    end
+
+    test "without a prev node inserted node will be first in list", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2
+    } do
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_node" => node_3.uuid
+      }
+
+      {:ok, new_node} = Outline.insert_node(node_attrs)
+
+      assert new_node.prev_id == nil
+      assert Outline.get_node!(nested_node_1.uuid).prev_id == new_node.uuid
+      assert Outline.get_node!(nested_node_2.uuid).prev_id == nested_node_1.uuid
+    end
+
+    test "without a parent node the inserted node will be put at the top", %{
+      parent_node: parent_node
+    } do
+      # another node in another episode without parent and prev node
+      node_fixture(parent_id: nil, prev_id: nil)
+      node_attrs = %{"content" => "new node", "episode_id" => parent_node.episode_id}
+      {:ok, new_node} = Outline.insert_node(node_attrs)
+
+      assert new_node.prev_id == nil
+      assert new_node.parent_id == nil
+      assert Outline.get_node!(parent_node.uuid).prev_id == new_node.uuid
+    end
+
+    test "parent node and prev node need to be consistent", %{
+      parent_node: parent_node,
+      nested_node_1: nested_node_1
+    } do
+      # new node cannot be inserted at level 1 and wants the lined in level 2
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => parent_node.episode_id,
+        "parent_node" => parent_node.uuid,
+        "prev_node" => nested_node_1.uuid
+      }
+
+      {:error, "Insert node failed. Parent and prev node are not consistent."} =
+        Outline.insert_node(node_attrs)
+    end
+
+    test "parent node and prev node need to be consistent (2)", %{
+      parent_node: parent_node
+    } do
+      bad_parent_node =
+        node_fixture(episode_id: parent_node.episode_id, parent_id: nil, prev_id: nil)
+
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => parent_node.episode_id,
+        "parent_node" => parent_node.uuid,
+        "prev_node" => bad_parent_node.uuid
+      }
+
+      {:error, _error_message} =
+        Outline.insert_node(node_attrs)
+    end
+
+    test "in case of error no node gets inserted", %{
+      parent_node: parent_node,
+      nested_node_1: nested_node_1
+    } do
+      count_nodes = Outline.count_nodes_by_episode(parent_node.episode_id)
+
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => parent_node.episode_id,
+        "parent_node" => parent_node.uuid,
+        "prev_node" => nested_node_1.uuid
+      }
+
+      {:error, _error_message} = Outline.insert_node(node_attrs)
+      new_count_nodes = Outline.count_nodes_by_episode(parent_node.episode_id)
+      # count stays the same
+      assert new_count_nodes == count_nodes
+    end
+  end
+
   describe "delete_node/1" do
     setup :complex_node_fixture
 
@@ -138,19 +311,9 @@ defmodule Radiator.OutlineTest do
       node_6: node_6
     } do
       episode_id = node_6.episode_id
-
-      count_nodes =
-        episode_id
-        |> Outline.list_nodes_by_episode()
-        |> Enum.count()
-
+      count_nodes = Outline.count_nodes_by_episode(episode_id)
       assert {:ok, %Node{}} = Outline.delete_node(node_6)
-
-      new_count_nodes =
-        episode_id
-        |> Outline.list_nodes_by_episode()
-        |> Enum.count()
-
+      new_count_nodes = Outline.count_nodes_by_episode(episode_id)
       assert new_count_nodes == count_nodes - 1
     end
 
@@ -160,19 +323,11 @@ defmodule Radiator.OutlineTest do
     } do
       episode_id = node_1.episode_id
 
-      count_nodes =
-        episode_id
-        |> Outline.list_nodes_by_episode()
-        |> Enum.count()
-
+      count_nodes = Outline.count_nodes_by_episode(episode_id)
       assert {:ok, %Node{}} = Outline.delete_node(node_1)
-
-      new_count_nodes =
-        episode_id
-        |> Outline.list_nodes_by_episode()
-        |> Enum.count()
-
+      new_count_nodes = Outline.count_nodes_by_episode(episode_id)
       assert new_count_nodes == count_nodes - 1
+
       node_2 = Outline.get_node!(node_2.uuid)
       assert node_2.prev_id == nil
     end
@@ -193,9 +348,9 @@ defmodule Radiator.OutlineTest do
       node_4: node_4,
       node_6: node_6,
       nested_node_2: nested_node_2,
-      parent: parent
+      parent_node: parent_node
     } do
-      assert {:ok, %Node{}} = Outline.delete_node(parent)
+      assert {:ok, %Node{}} = Outline.delete_node(parent_node)
 
       # test some of elements in the tree
       assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(node_1.uuid) end
@@ -208,8 +363,8 @@ defmodule Radiator.OutlineTest do
   describe "get_node_tree/1" do
     setup :complex_node_fixture
 
-    test "returns all nodes from a episode", %{parent: parent} do
-      episode_id = parent.episode_id
+    test "returns all nodes from a episode", %{parent_node: parent_node} do
+      episode_id = parent_node.episode_id
       assert {:ok, tree} = Outline.get_node_tree(episode_id)
 
       all_nodes = Outline.list_nodes_by_episode(episode_id)
@@ -223,45 +378,160 @@ defmodule Radiator.OutlineTest do
     end
 
     test "does not return a node from another episode", %{
-      parent: parent
+      parent_node: parent_node
     } do
-      episode_id = parent.episode_id
+      episode_id = parent_node.episode_id
       other_node = node_fixture(parent_id: nil, prev_id: nil, content: "other content")
       assert other_node.episode_id != episode_id
       {:ok, tree} = Outline.get_node_tree(episode_id)
       assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == []
     end
 
-    test "returns nodes sorted by level", %{parent: parent} do
-      episode_id = parent.episode_id
+    test "returns nodes sorted by level", %{parent_node: parent_node} do
+      episode_id = parent_node.episode_id
       {:ok, tree} = Outline.get_node_tree(episode_id)
 
       Enum.reduce(tree, 0, fn node, current_level ->
         if node.parent_id != nil do
-          parent = Enum.find(tree, fn n -> n.uuid == node.parent_id end)
-          assert parent.level + 1 == node.level
+          parent_node = Enum.find(tree, fn n -> n.uuid == node.parent_id end)
+          assert parent_node.level + 1 == node.level
         end
 
         assert node.level >= current_level
         node.level
       end)
     end
+
+    test "associated the correct level", %{
+      node_1: node_1,
+      node_2: node_2,
+      node_3: node_3,
+      node_4: node_4,
+      node_5: node_5,
+      node_6: node_6,
+      nested_node_1: nested_node_1,
+      nested_node_2: nested_node_2,
+      parent_node: parent_node
+    } do
+      {:ok, tree} = Outline.get_node_tree(parent_node.episode_id)
+      assert_level_for_node(tree, parent_node, 0)
+      assert_level_for_node(tree, node_1, 1)
+      assert_level_for_node(tree, node_2, 1)
+      assert_level_for_node(tree, node_3, 1)
+      assert_level_for_node(tree, node_4, 1)
+      assert_level_for_node(tree, node_5, 1)
+      assert_level_for_node(tree, node_6, 1)
+      assert_level_for_node(tree, nested_node_1, 2)
+      assert_level_for_node(tree, nested_node_2, 2)
+    end
+
+    test "tree can have more than one parent node", %{
+      parent_node: parent_node
+    } do
+      episode_id = parent_node.episode_id
+
+      other_parent_node =
+        node_fixture(
+          parent_id: nil,
+          prev_id: parent_node.uuid,
+          episode_id: episode_id,
+          content: "also a parent"
+        )
+
+      third_parent_node =
+        node_fixture(
+          parent_id: nil,
+          prev_id: other_parent_node.uuid,
+          episode_id: episode_id,
+          content: "even another root element"
+        )
+
+      {:ok, tree} = Outline.get_node_tree(parent_node.episode_id)
+      assert_level_for_node(tree, parent_node, 0)
+      assert_level_for_node(tree, other_parent_node, 0)
+      assert_level_for_node(tree, third_parent_node, 0)
+    end
+  end
+
+  defp assert_level_for_node(tree, node, level) do
+    node = Enum.filter(tree, fn n -> n.uuid == node.uuid end) |> List.first()
+    assert node.level == level
   end
 
   defp complex_node_fixture(_) do
     episode = PodcastFixtures.episode_fixture()
-    parent = node_fixture(episode_id: episode.id, parent_id: nil, prev_id: nil)
-    node_1 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: nil)
-    node_2 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_1.uuid)
-    node_3 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_2.uuid)
-    node_4 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_3.uuid)
-    node_5 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_4.uuid)
-    node_6 = node_fixture(episode_id: episode.id, parent_id: parent.uuid, prev_id: node_5.uuid)
 
-    nested_node_1 = node_fixture(episode_id: episode.id, parent_id: node_3.uuid, prev_id: nil)
+    parent_node =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: nil,
+        prev_id: nil,
+        content: "root of all evil"
+      )
+
+    node_1 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: parent_node.uuid,
+        prev_id: nil,
+        content: "node_1"
+      )
+
+    node_2 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: parent_node.uuid,
+        prev_id: node_1.uuid,
+        content: "node_2"
+      )
+
+    node_3 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: parent_node.uuid,
+        prev_id: node_2.uuid,
+        content: "node_3"
+      )
+
+    node_4 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: parent_node.uuid,
+        prev_id: node_3.uuid,
+        content: "node_4"
+      )
+
+    node_5 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: parent_node.uuid,
+        prev_id: node_4.uuid,
+        content: "node_5"
+      )
+
+    node_6 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: parent_node.uuid,
+        prev_id: node_5.uuid,
+        content: "node_6"
+      )
+
+    nested_node_1 =
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: node_3.uuid,
+        prev_id: nil,
+        content: "nested_node_1"
+      )
 
     nested_node_2 =
-      node_fixture(episode_id: episode.id, parent_id: node_3.uuid, prev_id: nested_node_1.uuid)
+      node_fixture(
+        episode_id: episode.id,
+        parent_id: node_3.uuid,
+        prev_id: nested_node_1.uuid,
+        content: "nested_node_2"
+      )
 
     %{
       node_1: node_1,
@@ -272,7 +542,7 @@ defmodule Radiator.OutlineTest do
       node_6: node_6,
       nested_node_1: nested_node_1,
       nested_node_2: nested_node_2,
-      parent: parent
+      parent_node: parent_node
     }
   end
 end

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -51,17 +51,17 @@ defmodule Radiator.OutlineTest do
       assert {:error, %Ecto.Changeset{}} = Outline.create_node(@invalid_attrs)
     end
 
-    test "update_node/2 with valid data updates the node" do
+    test "update_node_content/2 with valid data updates the node" do
       node = node_fixture()
       update_attrs = %{content: "some updated content"}
 
-      assert {:ok, %Node{} = node} = Outline.update_node(node, update_attrs)
+      assert {:ok, %Node{} = node} = Outline.update_node_content(node, update_attrs)
       assert node.content == "some updated content"
     end
 
-    test "update_node/2 with invalid data returns error changeset" do
+    test "update_node_content/2 with invalid data returns error changeset" do
       node = node_fixture()
-      assert {:error, %Ecto.Changeset{}} = Outline.update_node(node, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Outline.update_node_content(node, %{content: nil})
       assert node == Outline.get_node!(node.uuid)
     end
 
@@ -69,11 +69,6 @@ defmodule Radiator.OutlineTest do
       node = node_fixture()
       assert {:ok, %Node{}} = Outline.delete_node(node)
       assert_raise Ecto.NoResultsError, fn -> Outline.get_node!(node.uuid) end
-    end
-
-    test "change_node/1 returns a node changeset" do
-      node = node_fixture()
-      assert %Ecto.Changeset{} = Outline.change_node(node)
     end
   end
 end


### PR DESCRIPTION
Implements a tree aware `insert_node` and `delete_node`
Also a a fetch tree function based in CTE which are adding a virtual attribute level. 

I split the changeset of Node into different usecases. 


I needed to rebase which produced a tons of conflicts. So there might be some errors left.  For instance the broadcast function in `create_node` and `update_node_content` should be removed again I believe. I cannot remember that I was adding it ;) 

Questions arise:

Should all the tree aware functions to a new module?
do we still need a simple delete node or create node? At least ones that are public? 