### PR TITLE
Optional parent node for move node

### DIFF
--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -82,23 +82,23 @@ defmodule Radiator.Outline do
   # if no previous node is given, the new node will be inserted as the first child of the parent node
   def insert_node(attrs) do
     Repo.transaction(fn ->
-      prev_node_id = attrs["prev_id"]
-      parent_node_id = attrs["parent_id"]
+      prev_id = attrs["prev_id"]
+      parent_id = attrs["parent_id"]
       episode_id = attrs["episode_id"]
       # find Node which has been previously connected to prev_node
       next_node =
         Node
         |> where(episode_id: ^episode_id)
-        |> where_prev_node_equals(prev_node_id)
-        |> where_parent_node_equals(parent_node_id)
+        |> where_prev_node_equals(prev_id)
+        |> where_parent_node_equals(parent_id)
         |> Repo.one()
 
-      with prev_node <- NodeRepository.get_node_if(prev_node_id),
-           parent_node <- find_parent_node(prev_node, parent_node_id),
+      with prev_node <- NodeRepository.get_node_if(prev_id),
+           parent_node <- find_parent_node(prev_node, parent_id),
            true <- parent_and_prev_consistent?(parent_node, prev_node),
            true <- episode_valid?(episode_id, parent_node, prev_node),
            {:ok, node} <- NodeRepository.create_node(set_parent_id_if(attrs, parent_node)),
-           {:ok, _node_to_move} <- move_node_if(next_node, parent_node_id, node.uuid) do
+           {:ok, _node_to_move} <- move_node_if(next_node, parent_id, node.uuid) do
         %NodeRepoResult{node: node, next_id: get_node_id(next_node)}
       else
         false ->
@@ -455,11 +455,11 @@ defmodule Radiator.Outline do
 
   defp move_node_if(nil, _parent_node_id, _prev_node_id), do: {:ok, nil}
 
-  defp move_node_if(node, parent_node_id, prev_node_id) do
+  defp move_node_if(node, parent_id, prev_id) do
     node
     |> Node.move_node_changeset(%{
-      parent_id: parent_node_id,
-      prev_id: prev_node_id
+      parent_id: parent_id,
+      prev_id: prev_id
     })
     |> Repo.update()
   end

--- a/lib/radiator/outline/command.ex
+++ b/lib/radiator/outline/command.ex
@@ -33,13 +33,13 @@ defmodule Radiator.Outline.Command do
     }
   end
 
-  def build("move_node", node_id, parent_node_id, prev_node_id, user_id, event_id) do
+  def build("move_node", node_id, parent_id, prev_id, user_id, event_id) do
     %MoveNodeCommand{
       event_id: event_id,
       user_id: user_id,
       node_id: node_id,
-      parent_id: parent_node_id,
-      prev_id: prev_node_id
+      parent_id: parent_id,
+      prev_id: prev_id
     }
   end
 end

--- a/lib/radiator/outline/command_processor.ex
+++ b/lib/radiator/outline/command_processor.ex
@@ -64,7 +64,7 @@ defmodule Radiator.Outline.CommandProcessor do
          } = command
        ) do
     node_id
-    |> Outline.move_node(prev_id, parent_id)
+    |> Outline.move_node(prev_id: prev_id, parent_id: parent_id)
     |> handle_move_node_result(command)
   end
 

--- a/lib/radiator/outline/dispatch.ex
+++ b/lib/radiator/outline/dispatch.ex
@@ -15,7 +15,10 @@ defmodule Radiator.Outline.Dispatch do
     |> EventProducer.enqueue()
   end
 
-  def move_node(node_id, parent_node_id, prev_node_id, user_id, event_id) do
+  def move_node(node_id, user_id, event_id,
+        parent_node_id: parent_node_id,
+        prev_node_id: prev_node_id
+      ) do
     "move_node"
     |> Command.build(node_id, parent_node_id, prev_node_id, user_id, event_id)
     |> EventProducer.enqueue()

--- a/lib/radiator/outline/dispatch.ex
+++ b/lib/radiator/outline/dispatch.ex
@@ -16,11 +16,11 @@ defmodule Radiator.Outline.Dispatch do
   end
 
   def move_node(node_id, user_id, event_id,
-        parent_node_id: parent_node_id,
-        prev_node_id: prev_node_id
+        parent_id: parent_id,
+        prev_id: prev_id
       ) do
     "move_node"
-    |> Command.build(node_id, parent_node_id, prev_node_id, user_id, event_id)
+    |> Command.build(node_id, parent_id, prev_id, user_id, event_id)
     |> EventProducer.enqueue()
   end
 

--- a/lib/radiator_web/live/outline_component.ex
+++ b/lib/radiator_web/live/outline_component.ex
@@ -217,7 +217,7 @@ defmodule RadiatorWeb.OutlineComponent do
     }
 
     user_id = socket.assigns.user_id
-    Dispatch.move_node(uuid, user_id, generate_event_id(socket.id), prev_node_id: prev_id)
+    Dispatch.move_node(uuid, user_id, generate_event_id(socket.id), prev_id: prev_id)
 
     socket
     |> stream_insert(:nodes, to_change_form(node, %{}))
@@ -232,7 +232,7 @@ defmodule RadiatorWeb.OutlineComponent do
     }
 
     user_id = socket.assigns.user_id
-    Dispatch.move_node(uuid, user_id, generate_event_id(socket.id), parent_node_id: parent_id)
+    Dispatch.move_node(uuid, user_id, generate_event_id(socket.id), parent_id: parent_id)
 
     socket
     |> stream_insert(:nodes, to_change_form(node, %{}))

--- a/lib/radiator_web/live/outline_component.ex
+++ b/lib/radiator_web/live/outline_component.ex
@@ -217,7 +217,7 @@ defmodule RadiatorWeb.OutlineComponent do
     }
 
     user_id = socket.assigns.user_id
-    Dispatch.move_node(uuid, prev_id, nil, user_id, generate_event_id(socket.id))
+    Dispatch.move_node(uuid, user_id, generate_event_id(socket.id), prev_node_id: prev_id)
 
     socket
     |> stream_insert(:nodes, to_change_form(node, %{}))
@@ -232,7 +232,7 @@ defmodule RadiatorWeb.OutlineComponent do
     }
 
     user_id = socket.assigns.user_id
-    Dispatch.move_node(uuid, nil, parent_id, user_id, generate_event_id(socket.id))
+    Dispatch.move_node(uuid, user_id, generate_event_id(socket.id), parent_node_id: parent_id)
 
     socket
     |> stream_insert(:nodes, to_change_form(node, %{}))


### PR DESCRIPTION
I had to change the signature for `move_node` otherwise it would not be possible to differentiate between setting a value to `nil`and omitting the value. I used a keyword list since this a classic for optional parameters. Another option would be to use a map like for `insert_node`