### PR TITLE
feature: generate nodes from template

### DIFF
--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -1,15 +1,50 @@
 defmodule Radiator.OutlineTest do
-  alias Radiator.Outline.NodeRepoResult
   use Radiator.DataCase
+
+  import Ecto.Query, warn: false
+  import Radiator.OutlineFixtures
+  import Radiator.PodcastFixtures
 
   alias Radiator.Outline
   alias Radiator.Outline.Node
+  alias Radiator.Outline.NodeRepoResult
   alias Radiator.Outline.NodeRepository
   alias Radiator.Podcast
-  alias Radiator.PodcastFixtures
 
-  import Radiator.OutlineFixtures
-  import Ecto.Query, warn: false
+  describe "node_tree" do
+    test "generate from template" do
+      %{id: episode_id} = episode_fixture()
+
+      nodes =
+        [
+          {"node-1"},
+          {"node-2",
+           [
+             {"node-2_1"},
+             {"node-2_2"},
+             {"node-2_3"}
+           ]},
+          {"node-3"},
+          {"node-4",
+           [
+             {"node-4_1",
+              [
+                {"node-4_1_1"},
+                {"node-4_1_2",
+                 [
+                   {"node-4_1_2_1"}
+                 ]}
+              ]},
+             {"node-4_2"}
+           ]},
+          {"node-5"}
+        ]
+        |> node_tree_fixture(%{episode_id: episode_id})
+
+      assert length(nodes) == 13
+      assert Enum.all?(nodes, &match?(%Node{episode_id: ^episode_id}, &1))
+    end
+  end
 
   describe "update_node_content/2" do
     test "with valid data updates the node" do
@@ -1104,7 +1139,7 @@ defmodule Radiator.OutlineTest do
     setup :complex_node_fixture
 
     test "get child nodes in correct order" do
-      episode = PodcastFixtures.episode_fixture()
+      episode = episode_fixture()
 
       node_1 =
         node_fixture(

--- a/test/support/fixtures/outline_fixtures.ex
+++ b/test/support/fixtures/outline_fixtures.ex
@@ -27,4 +27,55 @@ defmodule Radiator.OutlineFixtures do
 
   defp get_episode(%{episode_id: id}), do: Podcast.get_episode!(id)
   defp get_episode(_), do: PodcastFixtures.episode_fixture()
+
+  @doc """
+  Generate a tree of nodes based on a human readable pseudo syntax.
+  [
+    {"node-1"},
+    {"node-2",
+      [
+        {"node-2_1"},
+        {"node-2_2",
+        [
+          {"node-2_2_1"}
+        ]}
+      ]}
+  ]
+  |> node_tree_fixture(%{episode_id: episode.id})
+
+  """
+  def node_tree_fixture(content, attrs, siblings \\ [])
+
+  def node_tree_fixture({content}, attrs, []) do
+    attrs
+    |> Map.merge(%{content: content, parent_id: attrs[:parent_id], prev_id: nil})
+    |> node_fixture()
+    |> List.wrap()
+  end
+
+  def node_tree_fixture({content}, attrs, [%{uuid: prev_id} | _]) do
+    attrs
+    |> Map.merge(%{content: content, parent_id: nil, prev_id: prev_id})
+    |> node_fixture()
+    |> List.wrap()
+  end
+
+  def node_tree_fixture({content, nodes}, attrs, siblings) when is_list(nodes) do
+    [node] = node_tree_fixture({content}, attrs, siblings)
+
+    attrs = Map.put(attrs, :parent_id, node.uuid)
+
+    children =
+      Enum.reduce(nodes, [], fn content, acc ->
+        acc ++ node_tree_fixture(content, attrs, acc)
+      end)
+
+    [node | children]
+  end
+
+  def node_tree_fixture(nodes, attrs, _siblings) when is_list(nodes) do
+    Enum.reduce(nodes, [], fn content, acc ->
+      acc ++ node_tree_fixture(content, attrs, acc)
+    end)
+  end
 end


### PR DESCRIPTION
use node_tree_fixture/2 to generate outline nodes described by an easy to read „template“ structure