### PR TITLE
refactor event data: instead of sending ids provide more infos

### DIFF
--- a/lib/radiator/event_store.ex
+++ b/lib/radiator/event_store.ex
@@ -12,7 +12,7 @@ defmodule Radiator.EventStore do
       create_event_data(%{
         data: Event.payload(event),
         event_type: Event.event_type(event),
-        uuid: convert_to_uuid(event.uuid),
+        uuid: convert_to_uuid(event.event_id),
         user_id: event.user_id
       })
 

--- a/lib/radiator/outline/command_processor.ex
+++ b/lib/radiator/outline/command_processor.ex
@@ -91,12 +91,12 @@ defmodule Radiator.Outline.CommandProcessor do
         result = Outline.remove_node(node)
 
         %NodeDeletedEvent{
-          node_id: node_id,
-          episode_id: node.episode_id,
-          uuid: command.event_id,
+          node: result.node,
+          episode_id: result.episode_id,
+          event_id: command.event_id,
           user_id: command.user_id,
           children: result.children,
-          next_id: result.next_id
+          next: result.next
         }
         |> EventStore.persist_event()
         |> Dispatch.broadcast()
@@ -105,13 +105,16 @@ defmodule Radiator.Outline.CommandProcessor do
     :ok
   end
 
-  defp handle_insert_node_result({:ok, %NodeRepoResult{node: node, next_id: next_id}}, command) do
+  defp handle_insert_node_result(
+         {:ok, %NodeRepoResult{node: node, next: next, episode_id: episode_id}},
+         command
+       ) do
     %NodeInsertedEvent{
       node: node,
-      uuid: command.event_id,
+      event_id: command.event_id,
       user_id: command.user_id,
-      next_id: next_id,
-      episode_id: node.episode_id
+      next: next,
+      episode_id: episode_id
     }
     |> EventStore.persist_event()
     |> Dispatch.broadcast()
@@ -129,15 +132,13 @@ defmodule Radiator.Outline.CommandProcessor do
         %MoveNodeCommand{} = command
       ) do
     %NodeMovedEvent{
-      node_id: node.uuid,
-      parent_id: command.parent_id,
-      prev_id: command.prev_id,
-      old_prev_id: result.old_prev_id,
-      old_next_id: result.old_next_id,
+      node: Outline.get_node_result_info(node),
+      old_prev: result.old_prev,
+      old_next: result.old_next,
       user_id: command.user_id,
-      uuid: command.event_id,
-      next_id: result.next_id,
-      episode_id: node.episode_id,
+      event_id: command.event_id,
+      next: result.next,
+      episode_id: result.episode_id,
       children: result.children
     }
     |> EventStore.persist_event()
@@ -151,15 +152,13 @@ defmodule Radiator.Outline.CommandProcessor do
         %IndentNodeCommand{} = command
       ) do
     %NodeMovedEvent{
-      node_id: node.uuid,
-      parent_id: result.node.parent_id,
-      prev_id: result.node.prev_id,
-      old_prev_id: result.old_prev_id,
-      old_next_id: result.old_next_id,
+      node: node,
+      old_prev: result.old_prev,
+      old_next: result.old_next,
       user_id: command.user_id,
-      uuid: command.event_id,
-      next_id: result.next_id,
-      episode_id: node.episode_id,
+      event_id: command.event_id,
+      next: result.next,
+      episode_id: result.episode_id,
       children: result.children
     }
     |> EventStore.persist_event()
@@ -173,15 +172,13 @@ defmodule Radiator.Outline.CommandProcessor do
         %OutdentNodeCommand{} = command
       ) do
     %NodeMovedEvent{
-      node_id: node.uuid,
-      parent_id: result.node.parent_id,
-      prev_id: result.node.prev_id,
-      old_prev_id: result.old_prev_id,
-      old_next_id: result.old_next_id,
+      node: node,
+      old_prev: result.old_prev,
+      old_next: result.old_next,
       user_id: command.user_id,
-      uuid: command.event_id,
-      next_id: result.next_id,
-      episode_id: node.episode_id
+      event_id: command.event_id,
+      next: result.next,
+      episode_id: result.episode_id
     }
     |> EventStore.persist_event()
     |> Dispatch.broadcast()
@@ -199,7 +196,7 @@ defmodule Radiator.Outline.CommandProcessor do
       node_id: node.uuid,
       content: node.content,
       user_id: command.user_id,
-      uuid: command.event_id,
+      event_id: command.event_id,
       episode_id: node.episode_id
     }
     |> EventStore.persist_event()

--- a/lib/radiator/outline/event.ex
+++ b/lib/radiator/outline/event.ex
@@ -12,11 +12,9 @@ defmodule Radiator.Outline.Event do
 
   def payload(%NodeInsertedEvent{} = event) do
     %{
-      node_id: event.node.uuid,
+      node: event.node,
       content: event.node.content,
-      parent_id: event.node.parent_id,
-      prev_id: event.node.prev_id,
-      next_id: event.next_id
+      next: event.next
     }
   end
 
@@ -26,21 +24,19 @@ defmodule Radiator.Outline.Event do
 
   def payload(%NodeDeletedEvent{} = event) do
     %{
-      node_id: event.node_id,
+      node: event.node,
       episode_id: event.episode_id,
       children: event.children,
-      next_id: event.next_id
+      next: event.next
     }
   end
 
   def payload(%NodeMovedEvent{} = event) do
     %{
-      node_id: event.node_id,
-      parent_id: event.parent_id,
-      prev_id: event.prev_id,
-      old_prev_id: event.old_prev_id,
-      old_next_id: event.old_next_id,
-      next_id: event.next_id
+      node: event.node,
+      old_prev: event.old_prev,
+      old_next: event.old_next,
+      next: event.next
     }
   end
 

--- a/lib/radiator/outline/event/node_content_changed_event.ex
+++ b/lib/radiator/outline/event/node_content_changed_event.ex
@@ -1,5 +1,5 @@
 defmodule Radiator.Outline.Event.NodeContentChangedEvent do
   @moduledoc false
 
-  defstruct [:uuid, :node_id, :content, :user_id, :episode_id]
+  defstruct [:event_id, :node_id, :content, :user_id, :episode_id]
 end

--- a/lib/radiator/outline/event/node_deleted_event.ex
+++ b/lib/radiator/outline/event/node_deleted_event.ex
@@ -1,4 +1,4 @@
 defmodule Radiator.Outline.Event.NodeDeletedEvent do
   @moduledoc false
-  defstruct [:uuid, :node_id, :user_id, :children, :next_id, :episode_id]
+  defstruct [:event_id, :node, :user_id, :children, :next, :episode_id]
 end

--- a/lib/radiator/outline/event/node_inserted_event.ex
+++ b/lib/radiator/outline/event/node_inserted_event.ex
@@ -1,5 +1,5 @@
 defmodule Radiator.Outline.Event.NodeInsertedEvent do
   @moduledoc false
 
-  defstruct [:uuid, :node, :user_id, :next_id, :episode_id]
+  defstruct [:event_id, :node, :user_id, :next, :episode_id, :content]
 end

--- a/lib/radiator/outline/event/node_moved_event.ex
+++ b/lib/radiator/outline/event/node_moved_event.ex
@@ -1,14 +1,12 @@
 defmodule Radiator.Outline.Event.NodeMovedEvent do
   @moduledoc false
   defstruct [
-    :uuid,
-    :node_id,
-    :parent_id,
-    :prev_id,
+    :event_id,
+    :node,
     :user_id,
-    :old_prev_id,
-    :old_next_id,
-    :next_id,
+    :old_prev,
+    :old_next,
+    :next,
     :episode_id,
     :children
   ]

--- a/lib/radiator_web/components/outline_components.ex
+++ b/lib/radiator_web/components/outline_components.ex
@@ -6,6 +6,8 @@ defmodule RadiatorWeb.OutlineComponents do
 
   alias RadiatorWeb.CoreComponents, as: Core
 
+  alias Radiator.Outline
+
   alias Radiator.Outline.Event.{
     NodeContentChangedEvent,
     NodeDeletedEvent,
@@ -128,7 +130,7 @@ defmodule RadiatorWeb.OutlineComponents do
     ~H"""
     <div class="px-2 bg-gray-200">
       <Core.icon name="hero-pencil-square-solid" class="w-5 h-5" />
-      <%= @event.uuid %>
+      <%= @event.event_id %>
     </div>
     <div class="px-2 ml-8">
       <pre><%= @event.node_id %> - NodeContentChanged</pre>
@@ -141,10 +143,10 @@ defmodule RadiatorWeb.OutlineComponents do
     ~H"""
     <div class="px-2 bg-gray-200">
       <Core.icon name="hero-archive-box-x-mark-solid" class="w-5 h-5" />
-      <%= @event.uuid %>
+      <%= @event.event_id %>
     </div>
     <div class="px-2 ml-8">
-      <pre><%= @event.node_id %> - NodeDeleted</pre>
+      <pre><%= @event.node.uuid %> - NodeDeleted</pre>
       <p>next node = ?</p>
       <p>child nodes = ?</p>
     </div>
@@ -155,13 +157,13 @@ defmodule RadiatorWeb.OutlineComponents do
     ~H"""
     <div class="px-2 bg-gray-200">
       <Core.icon name="hero-plus-solid" class="w-5 h-5" />
-      <%= @event.uuid %>
+      <%= @event.event_id %>
     </div>
     <div class="px-2 ml-8">
       <pre><%= @event.node.uuid %> - NodeInserted</pre>
       <p>parent_id = <%= @event.node.parent_id %></p>
       <p>prev_id = <%= @event.node.prev_id %></p>
-      <p>next_id = <%= @event.next_id %></p>
+      <p>next_id = <%= Outline.get_node_id(@event.next) %></p>
       <p>content = <%= @event.node.content %></p>
     </div>
     """
@@ -171,15 +173,15 @@ defmodule RadiatorWeb.OutlineComponents do
     ~H"""
     <div class="px-2 bg-gray-200">
       <Core.icon name="hero-arrows-pointing-out-solid" class="w-5 h-5" />
-      <%= @event.uuid %>
+      <%= @event.event_id %>
     </div>
     <div class="px-2 ml-8">
-      <pre><%= @event.node_id %> - NodeMoved</pre>
-      <p>parent_id = <%= @event.parent_id %></p>
-      <p>prev_id = <%= @event.prev_id %></p>
-      <p>old_prev_id = <%= @event.old_prev_id %></p>
-      <p>old_next_id = <%= @event.old_next_id %></p>
-      <p>next_id = <%= @event.next_id %></p>
+      <pre><%= @event.node.uuid %> - NodeMoved</pre>
+      <p>parent_id = <%= @event.node.parent_id %></p>
+      <p>prev_id = <%= @event.node.prev_id %></p>
+      <p>old_prev_id = <%= Outline.get_node_id(@event.old_prev) %></p>
+      <p>old_next_id = <%= Outline.get_node_id(@event.old_next) %></p>
+      <p>next_id = <%= Outline.get_node_id(@event.next) %></p>
     </div>
     """
   end

--- a/lib/radiator_web/live/episode_live/index.ex
+++ b/lib/radiator_web/live/episode_live/index.ex
@@ -26,7 +26,7 @@ defmodule RadiatorWeb.EpisodeLive.Index do
     |> assign(:show, show)
     |> assign(:episodes, show.episodes)
     |> assign(action: nil, episode: nil, form: nil)
-    |> stream_configure(:event_logs, dom_id: & &1.uuid)
+    |> stream_configure(:event_logs, dom_id: & &1.event_id)
     |> stream(:event_logs, get_event_logs(episode))
     |> reply(:ok)
   end

--- a/lib/radiator_web/live/outline_component.ex
+++ b/lib/radiator_web/live/outline_component.ex
@@ -192,6 +192,7 @@ defmodule RadiatorWeb.OutlineComponent do
     Dispatch.insert_node(params, user_id, generate_event_id(socket.id))
 
     socket
+    # TODO @sorax needs to be refactored, node is only a minor version without content
     |> stream_insert(:nodes, to_change_form(node, %{}))
     |> reply(:noreply)
   end

--- a/test/radiator/event_store_test.exs
+++ b/test/radiator/event_store_test.exs
@@ -22,15 +22,15 @@ defmodule Radiator.EventStoreTest do
       event = node_inserted_event_fixture(user_id: user.id)
 
       EventStore.persist_event(event)
-      stored_event = EventStore.get_event_data!(event.uuid)
-      assert stored_event.data["next_id"] == event.next_id
+      stored_event = EventStore.get_event_data!(event.event_id)
+      assert stored_event.data["next"]["uuid"] == event.next.uuid
       assert stored_event.user_id == event.user_id
       assert stored_event.event_type == "NodeInsertedEvent"
 
       assert stored_event.data["content"] == event.node.content
-      assert stored_event.data["parent_id"] == event.node.parent_id
-      assert stored_event.data["prev_id"] == event.node.prev_id
-      assert stored_event.data["node_id"] == event.node.uuid
+      assert stored_event.data["node"]["parent_id"] == event.node.parent_id
+      assert stored_event.data["node"]["prev_id"] == event.node.prev_id
+      assert stored_event.data["node"]["uuid"] == event.node.uuid
     end
 
     test "persists node_content_changed_event" do
@@ -65,12 +65,12 @@ defmodule Radiator.EventStoreTest do
       event = node_moved_event_fixture(user_id: user.id)
 
       EventStore.persist_event(event)
-      stored_event = EventStore.get_event_data!(event.uuid)
-      assert stored_event.data["node_id"] == event.node_id
-      assert stored_event.data["parent_id"] == event.parent_id
-      assert stored_event.data["prev_id"] == event.prev_id
-      assert stored_event.data["old_next_id"] == event.old_next_id
-      assert stored_event.data["next_id"] == event.next_id
+      stored_event = EventStore.get_event_data!(event.event_id)
+      assert stored_event.data["node"]["uuid"] == event.node.uuid
+      assert stored_event.data["node"]["parent_id"] == event.node.parent_id
+      assert stored_event.data["node"]["prev_id"] == event.node.prev_id
+      assert stored_event.data["old_next"]["uuid"] == event.old_next.uuid
+      assert stored_event.data["next"]["uuid"] == event.next.uuid
 
       assert stored_event.user_id == event.user_id
       assert stored_event.event_type == "NodeMovedEvent"

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -232,7 +232,7 @@ defmodule Radiator.OutlineTest do
         "prev_id" => node_2.uuid
       }
 
-      {:ok, %{next_id: next_id, node: new_node}} = Outline.insert_node(node_attrs)
+      {:ok, %{next: %{uuid: next_id}, node: new_node}} = Outline.insert_node(node_attrs)
       assert node_3.uuid == next_id
       assert NodeRepository.get_node!(node_3.uuid).prev_id == new_node.uuid
     end
@@ -746,8 +746,8 @@ defmodule Radiator.OutlineTest do
         Outline.move_node(node_1.uuid, prev_id: node_5.uuid, parent_id: node_2.parent_id)
 
       assert node_result.node.uuid == node_1.uuid
-      assert node_result.old_prev_id == nil
-      assert node_result.old_next_id == node_2.uuid
+      assert node_result.old_prev == nil
+      assert node_result.old_next.uuid == node_2.uuid
     end
 
     test "error when prev id is the same as node id", %{
@@ -831,7 +831,7 @@ defmodule Radiator.OutlineTest do
     } do
       {:ok, result} = Outline.indent_node(node_2.uuid)
       assert result.node.parent_id == node_1.uuid
-      assert result.old_prev_id == node_1.uuid
+      assert result.old_prev.uuid == node_1.uuid
     end
 
     # before 1 2

--- a/test/support/fixtures/event_store_fixtures.ex
+++ b/test/support/fixtures/event_store_fixtures.ex
@@ -40,8 +40,8 @@ defmodule Radiator.EventStoreFixtures do
     %NodeInsertedEvent{
       node: node,
       user_id: user_id,
-      uuid: Ecto.UUID.generate(),
-      next_id: next.uuid
+      event_id: Ecto.UUID.generate(),
+      next: next
     }
   end
 
@@ -52,7 +52,7 @@ defmodule Radiator.EventStoreFixtures do
       node_id: node.uuid,
       content: node.content,
       user_id: user_id,
-      uuid: Ecto.UUID.generate()
+      event_id: Ecto.UUID.generate()
     }
   end
 
@@ -60,16 +60,16 @@ defmodule Radiator.EventStoreFixtures do
     node = OutlineFixtures.node_fixture()
 
     %NodeDeletedEvent{
-      node_id: node.uuid,
+      node: node,
       user_id: user_id,
-      uuid: Ecto.UUID.generate()
+      event_id: Ecto.UUID.generate()
     }
   end
 
   def node_moved_event_fixture(user_id: user_id) do
     node = OutlineFixtures.node_fixture()
-    parent = OutlineFixtures.node_fixture(episode_id: node.episode_id)
-    prev = OutlineFixtures.node_fixture(episode_id: node.episode_id)
+    _parent = OutlineFixtures.node_fixture(episode_id: node.episode_id)
+    _prev = OutlineFixtures.node_fixture(episode_id: node.episode_id)
     next = OutlineFixtures.node_fixture(episode_id: node.episode_id)
     old_next = OutlineFixtures.node_fixture(episode_id: node.episode_id)
 
@@ -77,14 +77,12 @@ defmodule Radiator.EventStoreFixtures do
       OutlineFixtures.node_fixture(episode_id: node.episode_id)
 
     %NodeMovedEvent{
-      node_id: node.uuid,
+      node: %{uuid: node.uuid, parent_id: node.parent_id, prev_id: node.prev_id},
       user_id: user_id,
-      parent_id: parent.uuid,
-      prev_id: prev.uuid,
-      next_id: next.uuid,
-      old_next_id: old_next.uuid,
-      old_prev_id: old_prev.uuid,
-      uuid: Ecto.UUID.generate()
+      next: next,
+      old_next: old_next,
+      old_prev: old_prev,
+      event_id: Ecto.UUID.generate()
     }
   end
 end


### PR DESCRIPTION
so there is no need to make more db calls 

also change uuid in events to event_id
and add episode_id to NodeRepoResult

ATTENTION: some things seem broken with this change. E.g. after moving a node the content of some disappears. 
The focus gets lost after every nodechange