### PR TITLE
feature: adding slug field to episodes

### DIFF
--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -7,7 +7,7 @@ defmodule Radiator.Podcast.Episode do
   import Ecto.Changeset
 
   alias Radiator.Podcast.Show
-  @slug_max_length 50
+  @slug_max_length 500
 
   schema "episodes" do
     field :title, :string

--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -25,6 +25,7 @@ defmodule Radiator.Podcast.Episode do
     episode
     |> cast(attrs, [:title, :show_id, :number, :publish_date, :slug])
     |> validate_required([:title, :show_id, :number])
+    |> validate_length(:title, min: 3)
     |> maybe_update_slug()
   end
 

--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -7,11 +7,13 @@ defmodule Radiator.Podcast.Episode do
   import Ecto.Changeset
 
   alias Radiator.Podcast.Show
+  @slug_max_length 50
 
   schema "episodes" do
     field :title, :string
     field :number, :integer
     field :publish_date, :date
+    field :slug, :string
 
     belongs_to :show, Show
 
@@ -21,7 +23,32 @@ defmodule Radiator.Podcast.Episode do
   @doc false
   def changeset(episode, attrs) do
     episode
-    |> cast(attrs, [:title, :show_id, :number, :publish_date])
+    |> cast(attrs, [:title, :show_id, :number, :publish_date, :slug])
     |> validate_required([:title, :show_id, :number])
+    |> maybe_update_slug()
+    |> validate_slug()
+  end
+
+  defp maybe_update_slug(changeset) do
+    # Check if the title has changed
+    case get_change(changeset, :title) do
+      nil ->
+        # No title change, keep slug as is
+        changeset
+
+      new_title ->
+        new_slug = Slug.slugify(new_title, truncate: @slug_max_length)
+
+        changeset
+        |> put_change(:slug, new_slug)
+    end
+  end
+
+  defp validate_slug(changeset) do
+    changeset
+    |> validate_format(:slug, ~r/^[a-z0-9-]+$/,
+      message: "can only contain lowercase letters, numbers, and dashes"
+    )
+    |> validate_length(:slug, min: 3, max: @slug_max_length)
   end
 end

--- a/lib/radiator/podcast/episode.ex
+++ b/lib/radiator/podcast/episode.ex
@@ -26,7 +26,6 @@ defmodule Radiator.Podcast.Episode do
     |> cast(attrs, [:title, :show_id, :number, :publish_date, :slug])
     |> validate_required([:title, :show_id, :number])
     |> maybe_update_slug()
-    |> validate_slug()
   end
 
   defp maybe_update_slug(changeset) do
@@ -42,13 +41,5 @@ defmodule Radiator.Podcast.Episode do
         changeset
         |> put_change(:slug, new_slug)
     end
-  end
-
-  defp validate_slug(changeset) do
-    changeset
-    |> validate_format(:slug, ~r/^[a-z0-9-]+$/,
-      message: "can only contain lowercase letters, numbers, and dashes"
-    )
-    |> validate_length(:slug, min: 3, max: @slug_max_length)
   end
 end

--- a/lib/radiator_web/live/episode_live/index.html.heex
+++ b/lib/radiator_web/live/episode_live/index.html.heex
@@ -16,6 +16,8 @@
           <img src={"/images/pic1#{i}.jpg"} alt="" width="100" />
           <%= episode.number %>
           <%= episode.title %>
+          <br />
+          <%= episode.slug %>
         </.link>
       </li>
     </ol>

--- a/priv/repo/migrations/20240916151804_add_slug_to_episodes.exs
+++ b/priv/repo/migrations/20240916151804_add_slug_to_episodes.exs
@@ -1,0 +1,9 @@
+defmodule Radiator.Repo.Migrations.AddSlugToEpisodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:episodes) do
+      add :slug, :string
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -33,8 +33,7 @@ alias Radiator.Outline.NodeRepository
     title: "past episode",
     show_id: show.id,
     number: 1,
-    publish_date: Date.utc_today() |> Date.add(-23),
-    slug: Slug.slugify("past episode")
+    publish_date: Date.utc_today() |> Date.add(-23)
   })
 
 {:ok, current_episode} =
@@ -42,8 +41,7 @@ alias Radiator.Outline.NodeRepository
     title: "current episode",
     show_id: show.id,
     number: 2,
-    publish_date: Date.utc_today() |> Date.add(23),
-    slug: Slug.slugify("current episode")
+    publish_date: Date.utc_today() |> Date.add(23)
   })
 
 {:ok, node1} =

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -33,7 +33,8 @@ alias Radiator.Outline.NodeRepository
     title: "past episode",
     show_id: show.id,
     number: 1,
-    publish_date: Date.utc_today() |> Date.add(-23)
+    publish_date: Date.utc_today() |> Date.add(-23),
+    slug: Slug.slugify("past episode")
   })
 
 {:ok, current_episode} =
@@ -41,7 +42,8 @@ alias Radiator.Outline.NodeRepository
     title: "current episode",
     show_id: show.id,
     number: 2,
-    publish_date: Date.utc_today() |> Date.add(23)
+    publish_date: Date.utc_today() |> Date.add(23),
+    slug: Slug.slugify("current episode")
   })
 
 {:ok, node1} =

--- a/test/radiator/podcast_test.exs
+++ b/test/radiator/podcast_test.exs
@@ -146,6 +146,7 @@ defmodule Radiator.PodcastTest do
       assert episode.title == "some title"
       assert episode.show_id == show.id
       assert episode.number == 5
+      assert episode.slug == "some-title"
     end
 
     test "create_episode/1 with invalid data returns error changeset" do
@@ -160,6 +161,7 @@ defmodule Radiator.PodcastTest do
       assert {:ok, %Episode{} = episode} = Podcast.update_episode(episode, update_attrs)
       assert episode.title == "some updated title"
       assert episode.show_id == updated_podcast.id
+      assert episode.slug == "some-updated-title"
     end
 
     test "update_episode/2 with invalid data returns error changeset" do


### PR DESCRIPTION
Adding a `slug` field to Episode.
The `slug` will be generated from the `title`, every time the `title` changes the `slug` is also updated.