### PR TITLE
Feature/create show with hosts

### DIFF
--- a/lib/radiator/accounts.ex
+++ b/lib/radiator/accounts.ex
@@ -24,6 +24,25 @@ defmodule Radiator.Accounts do
   end
 
   @doc """
+  Returns a list of users search by using a partial email address
+
+  ## Examples
+
+      iex> search_users("foo@exampl")
+      [%User{email: "foo@example.com"}]
+
+      iex> search_users("unknown@example.com")
+      []
+
+  """
+  def search_users(search_term, limit \\ 10) do
+    User
+    |> where([u], ilike(u.email, ^"%#{search_term}%"))
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  @doc """
   Gets a user by email.
 
   ## Examples

--- a/lib/radiator/accounts/user.ex
+++ b/lib/radiator/accounts/user.ex
@@ -4,6 +4,7 @@ defmodule Radiator.Accounts.User do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias Radiator.Podcast.Show
 
   schema "users" do
     field :email, :string
@@ -11,6 +12,8 @@ defmodule Radiator.Accounts.User do
     field :hashed_password, :string, redact: true
     field :current_password, :string, virtual: true, redact: true
     field :confirmed_at, :utc_datetime
+
+    many_to_many :hosting_shows, Show, join_through: "show_hosts"
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/radiator/podcast/show.ex
+++ b/lib/radiator/podcast/show.ex
@@ -5,8 +5,8 @@ defmodule Radiator.Podcast.Show do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  alias Radiator.Podcast.{Episode, Network}
   alias Radiator.Accounts.User
+  alias Radiator.Podcast.{Episode, Network}
 
   schema "shows" do
     field :title, :string

--- a/lib/radiator/podcast/show.ex
+++ b/lib/radiator/podcast/show.ex
@@ -9,6 +9,7 @@ defmodule Radiator.Podcast.Show do
 
   schema "shows" do
     field :title, :string
+    field :description, :string
 
     belongs_to :network, Network
 
@@ -20,7 +21,7 @@ defmodule Radiator.Podcast.Show do
   @doc false
   def changeset(show, attrs) do
     show
-    |> cast(attrs, [:title, :network_id])
+    |> cast(attrs, [:title, :description, :network_id])
     |> validate_required([:title])
   end
 end

--- a/lib/radiator/podcast/show.ex
+++ b/lib/radiator/podcast/show.ex
@@ -6,6 +6,7 @@ defmodule Radiator.Podcast.Show do
   use Ecto.Schema
   import Ecto.Changeset
   alias Radiator.Podcast.{Episode, Network}
+  alias Radiator.Accounts.User
 
   schema "shows" do
     field :title, :string
@@ -14,6 +15,7 @@ defmodule Radiator.Podcast.Show do
     belongs_to :network, Network
 
     has_many(:episodes, Episode)
+    many_to_many(:hosts, User, join_through: "show_hosts")
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/radiator/radiator/podcast/show_hosts.ex
+++ b/lib/radiator/radiator/podcast/show_hosts.ex
@@ -1,8 +1,12 @@
 defmodule Radiator.Podcast.ShowHosts do
+  @moduledoc """
+    Represents the show_hosts model.
+    Used for many-to-many relationship between shows and users.
+  """
   use Ecto.Schema
   import Ecto.Changeset
-  alias Radiator.Podcast.Show
   alias Radiator.Accounts.User
+  alias Radiator.Podcast.Show
 
   schema "show_hosts" do
     belongs_to :show, Show

--- a/lib/radiator/radiator/podcast/show_hosts.ex
+++ b/lib/radiator/radiator/podcast/show_hosts.ex
@@ -1,0 +1,20 @@
+defmodule Radiator.Podcast.ShowHosts do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Radiator.Podcast.Show
+  alias Radiator.Accounts.User
+
+  schema "show_hosts" do
+    belongs_to :show, Show
+    belongs_to :user, User
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(show_hosts, attrs) do
+    show_hosts
+    |> cast(attrs, [:show_id, :user_id])
+    |> validate_required([:show_id, :user_id])
+  end
+end

--- a/lib/radiator_web/components/core_components.ex
+++ b/lib/radiator_web/components/core_components.ex
@@ -288,6 +288,7 @@ defmodule RadiatorWeb.CoreComponents do
   attr :prompt, :string, default: nil, doc: "the prompt for select inputs"
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
+  attr :class, :string, default: nil
 
   attr :rest, :global,
     include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
@@ -311,7 +312,7 @@ defmodule RadiatorWeb.CoreComponents do
       end)
 
     ~H"""
-    <div>
+    <div class={@class}>
       <label class="flex items-center gap-4 text-sm leading-6 text-zinc-600">
         <input type="hidden" name={@name} value="false" disabled={@rest[:disabled]} />
         <input
@@ -332,7 +333,7 @@ defmodule RadiatorWeb.CoreComponents do
 
   def input(%{type: "select"} = assigns) do
     ~H"""
-    <div>
+    <div class={@class}>
       <.label for={@id}><%= @label %></.label>
       <select
         id={@id}
@@ -351,7 +352,7 @@ defmodule RadiatorWeb.CoreComponents do
 
   def input(%{type: "textarea"} = assigns) do
     ~H"""
-    <div>
+    <div class={@class}>
       <.label for={@id}><%= @label %></.label>
       <textarea
         id={@id}
@@ -371,7 +372,7 @@ defmodule RadiatorWeb.CoreComponents do
   # All other inputs text, datetime-local, url, password, etc. are handled here...
   def input(assigns) do
     ~H"""
-    <div>
+    <div class={@class}>
       <.label for={@id}><%= @label %></.label>
       <input
         type={@type}

--- a/lib/radiator_web/live/admin_live/index.html.heex
+++ b/lib/radiator_web/live/admin_live/index.html.heex
@@ -54,6 +54,55 @@
       <.form :let={f} for={@form} id="show-form" phx-change="validate" phx-submit="save">
         <.input field={f[:title]} type="text" label="Title" />
         <.input field={f[:description]} type="text" label="Description" />
+        <div class="mt-4 flex items-end">
+          <.input
+            field={f[:host_email]}
+            type="text"
+            label="Add Hosts"
+            class="flex-grow"
+            placeholder="Search by email"
+            phx-debounce="300"
+            list="host-suggestions"
+            autocomplete="off"
+            phx-change="suggest_hosts"
+          />
+          <datalist id="host-suggestions">
+            <%= for suggestion <- @host_suggestions do %>
+              <option value={suggestion.email} />
+            <% end %>
+          </datalist>
+          <button
+            type="button"
+            class="ml-2 bg-[#df7366] text-white rounded px-4 py-2"
+            phx-click="add_host"
+          >
+            Add
+          </button>
+        </div>
+
+        <div class="mt-4 mb-4">
+          <h4 class="text-lg font-medium">Selected Hosts</h4>
+          <%= if Enum.empty?(@selected_hosts) do %>
+            <p class="mt-2 text-sm text-gray-500 italic">No hosts yet</p>
+          <% else %>
+            <ul class="mt-2 space-y-2">
+              <%= for host <- @selected_hosts do %>
+                <li class="flex items-center justify-between p-2 bg-gray-100 rounded-md">
+                  <span><%= host.email %></span>
+                  <button
+                    type="button"
+                    class="px-2 py-1 text-sm text-red-600 hover:text-red-800"
+                    phx-click="remove_host"
+                    phx-value-host-id={host.id}
+                  >
+                    Remove
+                  </button>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+        </div>
+
         <input name={f[:network_id].name} type="hidden" value={f[:network_id].value} />
         <div class="flex items-center justify-between gap-6 mt-2">
           <div

--- a/lib/radiator_web/live/admin_live/index.html.heex
+++ b/lib/radiator_web/live/admin_live/index.html.heex
@@ -53,6 +53,7 @@
       <h3 class="text-xl">Create Show</h3>
       <.form :let={f} for={@form} id="show-form" phx-change="validate" phx-submit="save">
         <.input field={f[:title]} type="text" label="Title" />
+        <.input field={f[:description]} type="text" label="Description" />
         <input name={f[:network_id].name} type="hidden" value={f[:network_id].value} />
         <div class="flex items-center justify-between gap-6 mt-2">
           <div

--- a/lib/radiator_web/live/episode_live/index.ex
+++ b/lib/radiator_web/live/episode_live/index.ex
@@ -22,7 +22,7 @@ defmodule RadiatorWeb.EpisodeLive.Index do
 
     socket
     |> assign(:page_title, show.title)
-    # |> assign(:page_description, "")
+    |> assign(:page_description, show.description)
     |> assign(:show, show)
     |> assign(:episodes, show.episodes)
     |> assign(action: nil, episode: nil, form: nil)

--- a/priv/repo/migrations/20240930153607_add_description_to_show.exs
+++ b/priv/repo/migrations/20240930153607_add_description_to_show.exs
@@ -1,0 +1,9 @@
+defmodule Radiator.Repo.Migrations.AddDescriptionToShow do
+  use Ecto.Migration
+
+  def change do
+    alter table(:shows) do
+      add :description, :string
+    end
+  end
+end

--- a/priv/repo/migrations/20240930193221_create_show_hosts.exs
+++ b/priv/repo/migrations/20240930193221_create_show_hosts.exs
@@ -1,0 +1,15 @@
+defmodule Radiator.Repo.Migrations.CreateShowHosts do
+  use Ecto.Migration
+
+  def change do
+    create table(:show_hosts) do
+      add :show_id, references(:shows, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :nothing)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:show_hosts, [:show_id])
+    create index(:show_hosts, [:user_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -23,10 +23,18 @@ alias Radiator.Outline.NodeRepository
   Podcast.create_network(%{title: "Podcast network"})
 
 {:ok, _show} =
-  Podcast.create_show(%{title: "Dev Cafe", network_id: network.id})
+  Podcast.create_show(%{
+    title: "Dev Cafe",
+    description: "Campfire chat between seasoned developers.",
+    network_id: network.id
+  })
 
 {:ok, show} =
-  Podcast.create_show(%{title: "Tech Weekly", network_id: network.id})
+  Podcast.create_show(%{
+    title: "Tech Weekly",
+    description: "Weekly discussion on latest topic out of the tech sphere.",
+    network_id: network.id
+  })
 
 {:ok, past_episode} =
   Podcast.create_episode(%{

--- a/test/radiator/accounts_test.exs
+++ b/test/radiator/accounts_test.exs
@@ -13,6 +13,24 @@ defmodule Radiator.AccountsTest do
     end
   end
 
+  describe "search_users/2" do
+    test "returns matching users" do
+      user1 = user_fixture(%{email: "foo@example.com"})
+      _user2 = user_fixture(%{email: "bar@example.com"})
+      assert Accounts.search_users("foo@exampl") == [user1]
+      assert Accounts.search_users("unknown@example.com") == []
+    end
+
+    test "respects the limit" do
+      for i <- 1..20 do
+        user_fixture(%{email: "user#{i}@example.com"})
+      end
+
+      assert length(Accounts.search_users("user", 5)) == 5
+      assert length(Accounts.search_users("user", 15)) == 15
+    end
+  end
+
   describe "get_user_by_email/1" do
     test "does not return the user if the email does not exist" do
       refute Accounts.get_user_by_email("unknown@example.com")

--- a/test/radiator/podcast_test.exs
+++ b/test/radiator/podcast_test.exs
@@ -2,6 +2,7 @@ defmodule Radiator.PodcastTest do
   use Radiator.DataCase
 
   import Radiator.PodcastFixtures
+  import Radiator.AccountsFixtures
 
   alias Radiator.Podcast
   alias Radiator.Podcast.{Episode, Network, Show}
@@ -95,6 +96,33 @@ defmodule Radiator.PodcastTest do
 
     test "create_show/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Podcast.create_show(@invalid_attrs)
+    end
+
+    test "create_show/2 with valid data creates a show with hosts" do
+      network = network_fixture()
+      valid_attrs = %{title: "some title", network_id: network.id}
+
+      hosts = [
+        user_fixture(%{email: "bob@example.com"}),
+        user_fixture(%{email: "jim@example.com"})
+      ]
+
+      assert {:ok, %Show{} = show} = Podcast.create_show(valid_attrs, hosts)
+      assert show.title == "some title"
+      assert show.network_id == network.id
+      show = Repo.preload(show, :hosts)
+      assert show.hosts == hosts
+    end
+
+    test "create_show/2 with invalid data returns error changeset" do
+      invalid_attrs = %{title: nil, network_id: nil}
+
+      hosts = [
+        user_fixture(%{email: "bob@example.com"}),
+        user_fixture(%{email: "jim@example.com"})
+      ]
+
+      assert {:error, %Ecto.Changeset{}} = Podcast.create_show(invalid_attrs, hosts)
     end
 
     test "update_show/2 with valid data updates the show" do


### PR DESCRIPTION
A reworked `Show` form with an added `description` field and a list of `hosts`.
The form contains a search field for searching through existing users by email.
Found users can be added to the list of hosts.

The form is still placed inside the Admin LiveView.
Extracting it into it's own details page and allowing editing as well would be done in another PR.

Some notes regarding creating the show with associated hosts:
It's done in steps inside a transaction.