### PR TITLE
 add userservices model

### DIFF
--- a/lib/radiator/accounts.ex
+++ b/lib/radiator/accounts.ex
@@ -252,10 +252,10 @@ defmodule Radiator.Accounts do
 
   ## Examples
 
-      iex> get_raindrop_tokens(23, "11r4", "11vb", ~U[2024-11-02 11:54:31Z])
+      iex> get_raindrop_tokens(23)
       %WebService{}
 
-      iex> get_raindrop_tokens(42, "11r4", "11vb", ~U[2024-11-02 11:54:31Z])
+      iex> get_raindrop_tokens(42)
       nil
 
   """
@@ -301,6 +301,30 @@ defmodule Radiator.Accounts do
       set: [updated_at: DateTime.utc_now()]
     )
   end
+
+  @doc """
+     Radiator.Accounts.connect_show_with_raindrop(1, 23, 42)
+  """
+  def connect_show_with_raindrop(user_id, show_id, collection_id) do
+    case get_raindrop_tokens(user_id) do
+      nil ->
+        {:error, "No Raindrop tokens found"}
+
+      %{data: data} = service ->
+        data =
+          Map.update!(data, :collection_mappings, fn mappings ->
+            Map.put(mappings, show_id_to_collection_id(show_id), collection_id)
+          end)
+          |> Map.from_struct()
+
+        service
+        |> WebService.changeset(%{data: data})
+        |> Repo.update()
+    end
+  end
+
+  defp show_id_to_collection_id(show_id) when is_integer(show_id), do: Integer.to_string(show_id)
+  defp show_id_to_collection_id(show_id), do: show_id
 
   ## Session
 

--- a/lib/radiator/accounts.ex
+++ b/lib/radiator/accounts.ex
@@ -260,9 +260,11 @@ defmodule Radiator.Accounts do
 
   """
   def get_raindrop_tokens(user_id) do
+    service_name = WebService.raindrop_service_name()
+
     WebService
     |> where([w], w.user_id == ^user_id)
-    |> where([w], w.service_name == "raindrop")
+    |> where([w], w.service_name == ^service_name)
     |> Repo.one()
   end
 
@@ -287,7 +289,7 @@ defmodule Radiator.Accounts do
       ) do
     %WebService{}
     |> WebService.changeset(%{
-      service_name: "raindrop",
+      service_name: WebService.raindrop_service_name(),
       user_id: user_id,
       data: %{
         access_token: raindrop_access_token,

--- a/lib/radiator/accounts/user.ex
+++ b/lib/radiator/accounts/user.ex
@@ -4,6 +4,7 @@ defmodule Radiator.Accounts.User do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias Radiator.Accounts.WebService
   alias Radiator.Podcast.Show
 
   schema "users" do
@@ -12,10 +13,8 @@ defmodule Radiator.Accounts.User do
     field :hashed_password, :string, redact: true
     field :current_password, :string, virtual: true, redact: true
     field :confirmed_at, :utc_datetime
-    field :raindrop_access_token, :string, redact: true
-    field :raindrop_refresh_token, :string, redact: true
-    field :raindrop_expires_at, :utc_datetime
 
+    has_many :services, WebService
     many_to_many :hosting_shows, Show, join_through: "show_hosts"
 
     timestamps(type: :utc_datetime)
@@ -135,17 +134,6 @@ defmodule Radiator.Accounts.User do
   def confirm_changeset(user) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
     change(user, confirmed_at: now)
-  end
-
-  @doc """
-  Sets the raindrop tokens and expiration time.
-  """
-  def set_raindrop_token_changeset(user, access_token, refresh_token, expires_at) do
-    change(user,
-      raindrop_access_token: access_token,
-      raindrop_refresh_token: refresh_token,
-      raindrop_expires_at: expires_at
-    )
   end
 
   @doc """

--- a/lib/radiator/accounts/web_service.ex
+++ b/lib/radiator/accounts/web_service.ex
@@ -12,11 +12,12 @@ defmodule Radiator.Accounts.WebService do
   schema "web_services" do
     field :service_name, :string
 
-    embeds_one :data, RaindropService do
+    embeds_one :data, RaindropService, on_replace: :delete, primary_key: false do
       field :access_token, :string, redact: true
       field :refresh_token, :string, redact: true
       field :expires_at, :utc_datetime
-      field :collection_mappings, :map
+      # Show ID => Raindrop Collection ID
+      field :collection_mappings, :map, default: %{}
     end
 
     belongs_to :user, User

--- a/lib/radiator/accounts/web_service.ex
+++ b/lib/radiator/accounts/web_service.ex
@@ -1,0 +1,40 @@
+defmodule Radiator.Accounts.WebService do
+  @moduledoc """
+    Model for storing all kinds of information about a user's service.
+    First implementation is for Raindrop.io
+    In the future we may have support for other services and https://hexdocs.pm/polymorphic_embed/ might be a solution
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Radiator.Accounts.User
+
+  schema "web_services" do
+    field :service_name, :string
+
+    embeds_one :data, RaindropService do
+      field :access_token, :string, redact: true
+      field :refresh_token, :string, redact: true
+      field :expires_at, :utc_datetime
+      field :collection_mappings, :map
+    end
+
+    belongs_to :user, User
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(service, attrs) do
+    service
+    |> cast(attrs, [:service_name, :user_id])
+    |> cast_embed(:data, required: true, with: &raindrop_changeset/2)
+    |> validate_required([:service_name, :data])
+  end
+
+  def raindrop_changeset(service, attrs \\ %{}) do
+    service
+    |> cast(attrs, [:access_token, :refresh_token, :expires_at, :collection_mappings])
+    |> validate_required([:access_token, :refresh_token, :expires_at])
+  end
+end

--- a/lib/radiator/accounts/web_service.ex
+++ b/lib/radiator/accounts/web_service.ex
@@ -9,6 +9,8 @@ defmodule Radiator.Accounts.WebService do
 
   alias Radiator.Accounts.User
 
+  @raindrop_service_name "raindrop"
+
   schema "web_services" do
     field :service_name, :string
 
@@ -38,4 +40,6 @@ defmodule Radiator.Accounts.WebService do
     |> cast(attrs, [:access_token, :refresh_token, :expires_at, :collection_mappings])
     |> validate_required([:access_token, :refresh_token, :expires_at])
   end
+
+  def raindrop_service_name, do: @raindrop_service_name
 end

--- a/lib/radiator_web/controllers/api/raindrop_controller.ex
+++ b/lib/radiator_web/controllers/api/raindrop_controller.ex
@@ -1,7 +1,6 @@
 defmodule RadiatorWeb.Api.RaindropController do
   use RadiatorWeb, :controller
 
-  alias Radiator.Accounts
   alias Radiator.Accounts.RaindropClient
   require Logger
 
@@ -10,36 +9,7 @@ defmodule RadiatorWeb.Api.RaindropController do
       "Raindrop auth redirect code: #{code}, redirect_uri: #{RaindropClient.redirect_uri()}"
     )
 
-    {:ok, response} =
-      [
-        method: :post,
-        url: "https://raindrop.io/oauth/access_token",
-        json: %{
-          client_id: RaindropClient.config()[:client_id],
-          client_secret: RaindropClient.config()[:client_secret],
-          grant_type: "authorization_code",
-          code: code,
-          redirect_uri: RaindropClient.redirect_uri()
-        }
-      ]
-      |> Keyword.merge(RaindropClient.config()[:options])
-      |> Req.request()
-
-    Logger.error("Response from raindrop: #{inspect(response)}")
-
-    if response.body != "Unauthorized" && !is_nil(response.body["access_token"]) do
-      expires_at =
-        DateTime.now!("Etc/UTC")
-        |> DateTime.shift(second: response.body["expires_in"])
-        |> DateTime.truncate(:second)
-
-      Accounts.update_raindrop_tokens(
-        user_id,
-        response.body["access_token"],
-        response.body["refresh_token"],
-        expires_at
-      )
-    end
+    RaindropClient.init_and_store_access_token(user_id, code)
 
     conn
     |> put_resp_content_type("application/json")

--- a/lib/radiator_web/controllers/api/raindrop_controller.ex
+++ b/lib/radiator_web/controllers/api/raindrop_controller.ex
@@ -2,7 +2,7 @@ defmodule RadiatorWeb.Api.RaindropController do
   use RadiatorWeb, :controller
 
   alias Radiator.Accounts
-  alias Radiator.RaindropClient
+  alias Radiator.Accounts.RaindropClient
   require Logger
 
   def auth_redirect(conn, %{"user_id" => user_id, "code" => code}) do

--- a/lib/radiator_web/live/admin_live/index.ex
+++ b/lib/radiator_web/live/admin_live/index.ex
@@ -2,8 +2,8 @@ defmodule RadiatorWeb.AdminLive.Index do
   use RadiatorWeb, :live_view
 
   alias Radiator.Accounts
+  alias Radiator.Accounts.RaindropClient
   alias Radiator.Podcast
-  alias Radiator.RaindropClient
   alias RadiatorWeb.Endpoint
 
   @impl true

--- a/lib/radiator_web/live/admin_live/index.ex
+++ b/lib/radiator_web/live/admin_live/index.ex
@@ -198,7 +198,9 @@ defmodule RadiatorWeb.AdminLive.Index do
 
   defp save_show(socket, :new_show, params) do
     case Podcast.create_show(params, socket.assigns.selected_hosts) do
-      {:ok, _show} ->
+      {:ok, show} ->
+        save_raindrop(socket, show.id, params)
+
         socket
         |> assign(:action, nil)
         |> assign(:networks, Podcast.list_networks(preload: :shows))
@@ -218,7 +220,9 @@ defmodule RadiatorWeb.AdminLive.Index do
 
   defp save_show(socket, :edit_show, params) do
     case Podcast.update_show(socket.assigns.show, params, socket.assigns.selected_hosts) do
-      {:ok, _show} ->
+      {:ok, show} ->
+        save_raindrop(socket, show.id, params)
+
         socket
         |> assign(:action, nil)
         |> assign(:networks, Podcast.list_networks(preload: :shows))
@@ -235,6 +239,13 @@ defmodule RadiatorWeb.AdminLive.Index do
         |> reply(:noreply)
     end
   end
+
+  # defp save_raindrop(socket, show_id, %{"show" => %{"raindrop_collection" => collection_id}}) do
+  defp save_raindrop(socket, show_id, %{"raindrop_collection" => collection_id}) do
+    Accounts.connect_show_with_raindrop(socket.assigns.current_user.id, show_id, collection_id)
+  end
+
+  defp save_raindrop(_socket, _show_id, _params), do: nil
 
   defp get_bookmarklet(api_uri, socket) do
     token =

--- a/lib/radiator_web/live/admin_live/index.html.heex
+++ b/lib/radiator_web/live/admin_live/index.html.heex
@@ -138,19 +138,12 @@
           <h4 class="text-lg font-medium">Raindrop Integration</h4>
           <%= if @raindrop_access do %>
             <p class="mt-2 text-sm italic text-gray-500">
-              <button
-                type="button"
-                class="px-2 py-1 text-sm text-red-600 hover:text-red-800"
-                phx-click="show_raindrop_collections"
-              >
-                <img src="/images/raindrop.jpg" alt="" width="32" />
-                <.input
-                  type="select"
-                  field={f[:raindrop_collection]}
-                  options={@raindrop_collections}
-                  prompt="Please select a collection for the show"
-                />
-              </button>
+              <.input
+                type="select"
+                field={f[:raindrop_collection]}
+                options={@raindrop_collections}
+                prompt="Please select a collection for the show"
+              />
             </p>
           <% else %>
             <a href={@raindrop_url} target="_blank">

--- a/priv/repo/migrations/20241105184254_create_web_services.exs
+++ b/priv/repo/migrations/20241105184254_create_web_services.exs
@@ -1,0 +1,16 @@
+defmodule Radiator.Repo.Migrations.CreateWebServices do
+  use Ecto.Migration
+
+  def change do
+    create table(:web_services) do
+      add :service_name, :string
+      add :data, :map
+      add :user_id, references(:users, on_delete: :nothing)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:web_services, [:user_id])
+    create unique_index(:web_services, [:user_id, :service_name])
+  end
+end

--- a/priv/repo/migrations/20241106201557_remove_rainbow_tokens_from_user.exs
+++ b/priv/repo/migrations/20241106201557_remove_rainbow_tokens_from_user.exs
@@ -1,0 +1,11 @@
+defmodule Radiator.Repo.Migrations.RemoveRainbowTokensFromUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      remove :raindrop_access_token, :string
+      remove :raindrop_refresh_token, :string
+      remove :raindrop_expires_at, :utc_datetime
+    end
+  end
+end

--- a/test/radiator/accounts/raindrop_client_test.exs
+++ b/test/radiator/accounts/raindrop_client_test.exs
@@ -1,0 +1,26 @@
+defmodule Radiator.Accounts.RaindropClientTest do
+  use Radiator.DataCase
+
+  import Radiator.AccountsFixtures
+
+  alias Radiator.Accounts.RaindropClient
+
+  describe "access_enabled?" do
+    test "true when a webservice entry for this user exists" do
+      webservice = raindrop_service_fixture()
+      assert RaindropClient.access_enabled?(webservice.user_id)
+    end
+
+    test "false when no webservice entry exists" do
+      user = user_fixture()
+      refute RaindropClient.access_enabled?(user.id)
+    end
+
+    test "false when no webservice entry for this user exists" do
+      other_user_id = raindrop_service_fixture().user_id
+      user = user_fixture()
+      assert other_user_id != user.id
+      refute RaindropClient.access_enabled?(user.id)
+    end
+  end
+end

--- a/test/radiator/accounts_test.exs
+++ b/test/radiator/accounts_test.exs
@@ -4,7 +4,7 @@ defmodule Radiator.AccountsTest do
   alias Radiator.Accounts
 
   import Radiator.AccountsFixtures
-  alias Radiator.Accounts.{User, UserToken}
+  alias Radiator.Accounts.{User, UserToken, WebService}
 
   describe "list_users/0" do
     test "returns all users" do
@@ -623,25 +623,76 @@ defmodule Radiator.AccountsTest do
     end
   end
 
-  describe "update_raindrop_tokens/4" do
+  describe "get_raindrop_tokens/1" do
     setup do
-      %{user: user_fixture()}
+      %{web_service: raindrop_service_fixture()}
     end
 
-    test "updates the raindrop tokens", %{user: user} do
-      access_token = "ae261404-11r4-47c0-bce3-e18a423da828"
-      refresh_token = "c8080368-fad2-4a3f-b2c9-71d3z85011vb"
+    test "returns the raindrop tokens", %{web_service: web_service} do
+      fetched_web_service = Accounts.get_raindrop_tokens(web_service.user_id)
+      assert fetched_web_service.data == web_service.data
+    end
+  end
 
-      expires_at =
-        DateTime.utc_now() |> DateTime.shift(second: 1_209_599) |> DateTime.truncate(:second)
+  describe "update_raindrop_tokens/4" do
+    setup do
+      user = user_fixture()
 
-      {:ok, user} =
-        Accounts.update_raindrop_tokens(user.id, access_token, refresh_token, expires_at)
+      web_service = %{
+        user_id: user.id,
+        access_token: "ae261404-11r4-47c0-bce3-e18a423da828",
+        refresh_token: "c8080368-fad2-4a3f-b2c9-71d3z85011vb",
+        expires_at:
+          DateTime.utc_now() |> DateTime.shift(second: 1_209_599) |> DateTime.truncate(:second)
+      }
 
-      user = Repo.reload(user)
-      assert user.raindrop_access_token == access_token
-      assert user.raindrop_refresh_token == refresh_token
-      assert user.raindrop_expires_at == expires_at
+      %{user: user, web_service: web_service}
+    end
+
+    test "creates a new entry if none exists", %{user: user, web_service: web_service} do
+      count_before = Repo.aggregate(WebService, :count)
+
+      Accounts.update_raindrop_tokens(
+        user.id,
+        web_service.access_token,
+        web_service.refresh_token,
+        web_service.expires_at
+      )
+
+      count_after = Repo.aggregate(WebService, :count)
+      assert count_after == count_before + 1
+
+      %WebService{} = service = Accounts.get_raindrop_tokens(user.id)
+
+      assert service.data.access_token == web_service.access_token
+      assert service.data.refresh_token == web_service.refresh_token
+      assert service.data.expires_at == web_service.expires_at
+    end
+
+    test "updates the raindrop tokens", %{user: user, web_service: web_service} do
+      # Create a new entry
+      Accounts.update_raindrop_tokens(
+        user.id,
+        web_service.access_token,
+        web_service.refresh_token,
+        web_service.expires_at
+      )
+
+      count_before = Repo.aggregate(WebService, :count)
+      # Update the entry, must not create a new one
+      Accounts.update_raindrop_tokens(
+        user.id,
+        "new-access-token",
+        "new-refresh-token",
+        web_service.expires_at
+      )
+
+      count_after = Repo.aggregate(WebService, :count)
+      assert count_after == count_before
+
+      %WebService{} = service = Accounts.get_raindrop_tokens(user.id)
+      assert service.data.access_token == "new-access-token"
+      assert service.data.refresh_token == "new-refresh-token"
     end
   end
 end

--- a/test/radiator_web/controllers/api/raindrop_controller_test.exs
+++ b/test/radiator_web/controllers/api/raindrop_controller_test.exs
@@ -1,11 +1,12 @@
 defmodule RadiatorWeb.Api.RaindropControllerTest do
   use RadiatorWeb.ConnCase, async: true
 
+  alias Radiator.Accounts.RaindropClient
   alias Radiator.AccountsFixtures
 
   describe "GET /raindrop/auth/redirect/:user_id" do
     setup %{conn: conn} do
-      raindrop = Radiator.RaindropClient.config()
+      raindrop = RaindropClient.config()
       %{host: host, path: path} = URI.parse(raindrop.url)
 
       %{

--- a/test/support/fixtures/accounts_fixtures.ex
+++ b/test/support/fixtures/accounts_fixtures.ex
@@ -28,4 +28,16 @@ defmodule Radiator.AccountsFixtures do
     [_, token | _] = String.split(captured_email.text_body, "[TOKEN]")
     token
   end
+
+  def raindrop_service_fixture(user \\ user_fixture()) do
+    {:ok, service} =
+      Radiator.Accounts.update_raindrop_tokens(
+        user.id,
+        "ae261404-11r4-47c0-bce3-e18a423da828",
+        "c8080368-fad2-4a3f-b2c9-71d3z85011vb",
+        DateTime.utc_now() |> DateTime.shift(second: 1_209_599) |> DateTime.truncate(:second)
+      )
+
+    service
+  end
 end


### PR DESCRIPTION
Introduces a new schema `web_services` which is supposed to store data for all kinds of possible external services. First implementation is for `Raindrop.io`. Hence the branchname the embedded data for the service it is not yet polymorphic. 
In the Admin Show settings a show can now be associated with a raindrop collection. 
Still missing: URL synchonization with an inbox folder. 