### PR TITLE
Feature/add show id to nodes

### DIFF
--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -88,7 +88,10 @@ defmodule Radiator.Outline do
 
       with true <- parent_and_prev_consistent?(parent_node, prev_node),
            true <- episode_valid?(episode_id, parent_node, prev_node),
-           {:ok, node} <- NodeRepository.create_node(set_parent_id_if(attrs, parent_node)),
+           {:ok, node} <-
+             attrs
+             |> set_parent_id_if(parent_node)
+             |> NodeRepository.create_node(),
            {:ok, _node_to_move} <-
              NodeRepository.move_node_if(next_node, get_node_id(parent_node), node.uuid) do
         %NodeRepoResult{node: node, next: get_node_result_info(next_node), episode_id: episode_id}

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -21,6 +21,8 @@ defmodule Radiator.Outline do
   alias Radiator.Outline.NodeRepoResult
   alias Radiator.Outline.NodeRepository
   alias Radiator.Outline.Validations, as: NodeValidator
+  alias Radiator.Podcast
+  alias Radiator.Podcast.Episode
   alias Radiator.Repo
 
   require Logger
@@ -74,7 +76,7 @@ defmodule Radiator.Outline do
   # if a previous node is given, the new node will be inserted after the previous node
   # if no parent is given, the new node will be inserted as a root node
   # if no previous node is given, the new node will be inserted as the first child of the parent node
-  def insert_node(attrs) do
+  def insert_node(%{"show_id" => _show_id} = attrs) do
     Repo.transaction(fn ->
       prev_id = attrs["prev_id"]
       parent_id = attrs["parent_id"]
@@ -104,6 +106,14 @@ defmodule Radiator.Outline do
           Repo.rollback("Insert node failed. Unknown error")
       end
     end)
+  end
+
+  def insert_node(%{"episode_id" => episode_id} = attrs) do
+    %Episode{show_id: show_id} = Podcast.get_episode!(episode_id)
+
+    attrs
+    |> Map.put("show_id", show_id)
+    |> insert_node()
   end
 
   @doc """

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -5,7 +5,7 @@ defmodule Radiator.Outline.Node do
   use Ecto.Schema
   import Ecto.Changeset
   alias Radiator.Outline.Node
-  alias Radiator.Podcast.Episode
+  alias Radiator.Podcast.{Episode, Show}
   alias Radiator.Resources.Url
 
   @derive {Jason.Encoder, only: [:uuid, :content, :creator_id, :parent_id, :prev_id]}
@@ -17,6 +17,7 @@ defmodule Radiator.Outline.Node do
     field :level, :integer, virtual: true
 
     belongs_to :episode, Episode
+    belongs_to :show, Show
     belongs_to :parent, Node, references: :uuid, type: Ecto.UUID
     belongs_to :prev, Node, references: :uuid, type: Ecto.UUID
     has_many :urls, Url, foreign_key: :node_id
@@ -31,9 +32,18 @@ defmodule Radiator.Outline.Node do
   """
   def insert_changeset(node, attributes) do
     node
-    |> cast(attributes, [:uuid, :content, :episode_id, :creator_id, :parent_id, :prev_id])
+    |> cast(attributes, [
+      :uuid,
+      :content,
+      :episode_id,
+      :creator_id,
+      :parent_id,
+      :prev_id,
+      :show_id
+    ])
     |> put_uuid()
     |> validate_required([:episode_id])
+    # |> validate_required([:show_id]) # TODO
     |> validate_format(:uuid, ~r/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
     |> unique_constraint(:uuid, name: "outline_nodes_pkey")
   end

--- a/lib/radiator/podcast/show.ex
+++ b/lib/radiator/podcast/show.ex
@@ -6,6 +6,7 @@ defmodule Radiator.Podcast.Show do
   use Ecto.Schema
   import Ecto.Changeset
   alias Radiator.Accounts.User
+  alias Radiator.Outline.Node
   alias Radiator.Podcast.{Episode, Network}
 
   schema "shows" do
@@ -15,6 +16,7 @@ defmodule Radiator.Podcast.Show do
     belongs_to :network, Network
 
     has_many(:episodes, Episode)
+    has_many(:outline_nodes, Node)
     many_to_many(:hosts, User, join_through: "show_hosts")
 
     timestamps(type: :utc_datetime)

--- a/priv/repo/migrations/20241124094719_add_show_id_to_nodes.exs
+++ b/priv/repo/migrations/20241124094719_add_show_id_to_nodes.exs
@@ -1,0 +1,11 @@
+defmodule Radiator.Repo.Migrations.AddShowIdToNodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:outline_nodes) do
+      add :show_id, references(:shows, on_delete: :nothing)
+    end
+
+    create index(:outline_nodes, [:show_id])
+  end
+end

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -152,6 +152,23 @@ defmodule Radiator.OutlineTest do
       assert new_node.prev_id == nested_node_1.uuid
     end
 
+    test "the show_id gets set - even if not given", %{
+      node_3: node_3,
+      nested_node_1: nested_node_1
+    } do
+      node_attrs = %{
+        "content" => "new node",
+        "episode_id" => node_3.episode_id,
+        "parent_id" => node_3.uuid,
+        "prev_id" => nested_node_1.uuid
+      }
+
+      {:ok, %{node: new_node}} = Outline.insert_node(node_attrs)
+
+      episode = Podcast.get_episode!(node_3.episode_id)
+      assert new_node.show_id == episode.show_id
+    end
+
     test "the next node - if existing - changes its prev_id and gets returned", %{
       node_2: node_2,
       node_3: node_3

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -13,7 +13,7 @@ defmodule Radiator.OutlineTest do
 
   describe "node_tree" do
     test "generate from template" do
-      %{id: episode_id} = episode_fixture()
+      %{id: episode_id, show_id: show_id} = episode_fixture()
 
       nodes =
         [
@@ -39,7 +39,7 @@ defmodule Radiator.OutlineTest do
            ]},
           {"node-5"}
         ]
-        |> node_tree_fixture(%{episode_id: episode_id})
+        |> node_tree_fixture(%{episode_id: episode_id, show_id: show_id})
 
       assert length(nodes) == 13
       assert Enum.all?(nodes, &match?(%Node{episode_id: ^episode_id}, &1))

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -66,6 +66,7 @@ defmodule Radiator.DataCase do
     node_1 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: nil,
         prev_id: nil,
         content: "node_1"
@@ -74,6 +75,7 @@ defmodule Radiator.DataCase do
     node_2 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: nil,
         prev_id: node_1.uuid,
         content: "node_2"
@@ -96,6 +98,7 @@ defmodule Radiator.DataCase do
     node_1 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: nil,
         prev_id: nil,
         content: "node_1"
@@ -104,6 +107,7 @@ defmodule Radiator.DataCase do
     node_2 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: node_1.uuid,
         prev_id: nil,
         content: "node_2"
@@ -121,6 +125,7 @@ defmodule Radiator.DataCase do
     parent_node =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: nil,
         prev_id: nil,
         content: "root of all evil"
@@ -129,6 +134,7 @@ defmodule Radiator.DataCase do
     node_1 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: parent_node.uuid,
         prev_id: nil,
         content: "node_1"
@@ -137,6 +143,7 @@ defmodule Radiator.DataCase do
     node_2 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: parent_node.uuid,
         prev_id: node_1.uuid,
         content: "node_2"
@@ -145,6 +152,7 @@ defmodule Radiator.DataCase do
     node_3 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: parent_node.uuid,
         prev_id: node_2.uuid,
         content: "node_3"
@@ -153,6 +161,7 @@ defmodule Radiator.DataCase do
     node_4 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: parent_node.uuid,
         prev_id: node_3.uuid,
         content: "node_4"
@@ -161,6 +170,7 @@ defmodule Radiator.DataCase do
     node_5 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: parent_node.uuid,
         prev_id: node_4.uuid,
         content: "node_5"
@@ -169,6 +179,7 @@ defmodule Radiator.DataCase do
     node_6 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: parent_node.uuid,
         prev_id: node_5.uuid,
         content: "node_6"
@@ -177,6 +188,7 @@ defmodule Radiator.DataCase do
     nested_node_1 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: node_3.uuid,
         prev_id: nil,
         content: "nested_node_1"
@@ -185,6 +197,7 @@ defmodule Radiator.DataCase do
     nested_node_2 =
       node_fixture(
         episode_id: episode.id,
+        show_id: episode.show_id,
         parent_id: node_3.uuid,
         prev_id: nested_node_1.uuid,
         content: "nested_node_2"

--- a/test/support/fixtures/outline_fixtures.ex
+++ b/test/support/fixtures/outline_fixtures.ex
@@ -19,7 +19,8 @@ defmodule Radiator.OutlineFixtures do
       attrs
       |> Enum.into(%{
         content: "some content",
-        episode_id: episode.id
+        episode_id: episode.id,
+        show_id: episode.show_id
       })
       |> NodeRepository.create_node()
 


### PR DESCRIPTION
The changes in the pull request include:

- Modified the `insert_node` function to handle nodes with `show_id` and `episode_id`.
- Updated the `insert_node` function to fetch `show_id` from the `Podcast` module.
- Added `show_id` field to the `Radiator.Outline.Node` schema and updated related functions and tests.
- Created a new migration file to add `show_id` to nodes.
- Updated various test fixtures and test cases to include `show_id` when creating nodes.
- Modified the `OutlineTest` to check for `show_id` in nodes and ensure it is set correctly.

These changes introduce `show_id` to nodes, ensuring that nodes are associated with a show and an episode, and update the necessary functions, tests, and fixtures to support this new field.