### PR TITLE
Remove all podcast related infos from outline nodes.

### DIFF
--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -1,6 +1,8 @@
 defmodule Radiator.EpisodeOutliner do
+  @moduledoc """
+    perhaps an intermediate module to connect the outliner and the episode
+  """
   alias Radiator.Outline.NodeRepository
-  # alias Radiator.Outline
   alias Radiator.Podcast
   alias Radiator.Podcast.Episode
 

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -1,6 +1,6 @@
 defmodule Radiator.EpisodeOutliner do
   @moduledoc """
-    perhaps an intermediate module to connect the outliner and the episode
+    an intermediate module to connect the outliner and the episode
   """
   alias Radiator.Outline.Node
   alias Radiator.Podcast

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -6,14 +6,6 @@ defmodule Radiator.EpisodeOutliner do
   alias Radiator.Podcast
   alias Radiator.Podcast.Episode
 
-  def insert_node(%{"episode_id" => episode_id} = attrs) do
-    %Episode{outline_node_container: outline_node_container} = Podcast.get_episode!(episode_id)
-
-    attrs
-    |> Map.put("outline_node_container", outline_node_container)
-    |> insert_node()
-  end
-
   def episode_id_for_node(node) do
     node
     |> episode_for_node()
@@ -22,10 +14,6 @@ defmodule Radiator.EpisodeOutliner do
 
   def episode_for_node(%Node{outline_node_container_id: outline_node_container_id}) do
     Podcast.get_episode_by_container_id(outline_node_container_id)
-    # case Podcast.get_episode_by_container_id(outline_node_container_id) do
-    #   {:ok, episode} -> episode
-    #   _ -> nil
-    # end
   end
 
   defp episode_id(nil), do: nil

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -6,16 +6,6 @@ defmodule Radiator.EpisodeOutliner do
   alias Radiator.Podcast
   alias Radiator.Podcast.Episode
 
-  @doc """
-  Returns a list of all child nodes.
-  """
-  def list_nodes_by_episode_sorted(episode_id) do
-    %Episode{outline_node_container: outline_node_container} = Podcast.get_episode!(episode_id)
-
-    outline_node_container
-    |> NodeRepository.list_nodes_by_node_container()
-  end
-
   def insert_node(%{"episode_id" => episode_id} = attrs) do
     %Episode{outline_node_container: outline_node_container} = Podcast.get_episode!(episode_id)
 

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -1,0 +1,24 @@
+defmodule Radiator.EpisodeOutliner do
+  alias Radiator.Outline.NodeRepository
+  # alias Radiator.Outline
+  alias Radiator.Podcast
+  alias Radiator.Podcast.Episode
+
+  @doc """
+  Returns a list of all child nodes.
+  """
+  def list_nodes_by_episode_sorted(episode_id) do
+    %Episode{outline_node_container: outline_node_container} = Podcast.get_episode!(episode_id)
+
+    outline_node_container
+    |> NodeRepository.list_nodes_by_node_container()
+  end
+
+  def insert_node(%{"episode_id" => episode_id} = attrs) do
+    %Episode{outline_node_container: outline_node_container} = Podcast.get_episode!(episode_id)
+
+    attrs
+    |> Map.put("outline_node_container", outline_node_container)
+    |> insert_node()
+  end
+end

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -2,6 +2,7 @@ defmodule Radiator.EpisodeOutliner do
   @moduledoc """
     perhaps an intermediate module to connect the outliner and the episode
   """
+  alias Radiator.Outline.Node
   alias Radiator.Podcast
   alias Radiator.Podcast.Episode
 
@@ -12,4 +13,21 @@ defmodule Radiator.EpisodeOutliner do
     |> Map.put("outline_node_container", outline_node_container)
     |> insert_node()
   end
+
+  def episode_id_for_node(node) do
+    node
+    |> episode_for_node()
+    |> episode_id()
+  end
+
+  def episode_for_node(%Node{outline_node_container_id: outline_node_container_id}) do
+    Podcast.get_episode_by_container_id(outline_node_container_id)
+    # case Podcast.get_episode_by_container_id(outline_node_container_id) do
+    #   {:ok, episode} -> episode
+    #   _ -> nil
+    # end
+  end
+
+  defp episode_id(nil), do: nil
+  defp episode_id(%Episode{id: id}), do: id
 end

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -2,7 +2,6 @@ defmodule Radiator.EpisodeOutliner do
   @moduledoc """
     perhaps an intermediate module to connect the outliner and the episode
   """
-  alias Radiator.Outline.NodeRepository
   alias Radiator.Podcast
   alias Radiator.Podcast.Episode
 

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -47,13 +47,12 @@ defmodule Radiator.Outline do
   end
 
   @doc """
-    Returns a list of all child nodes.
-    TODO: check wether we really need this function
-    """
-    def list_nodes_by_container_sorted(container_id) do
-      NodeRepository.list_nodes_by_node_container(container_id)
-    end
-
+  Returns a list of all child nodes.
+  TODO: check wether we really need this function
+  """
+  def list_nodes_by_container_sorted(container_id) do
+    NodeRepository.list_nodes_by_node_container(container_id)
+  end
 
   @doc """
   Inserts a node.
@@ -488,10 +487,18 @@ defmodule Radiator.Outline do
 
     Repo.transaction(fn ->
       old_next_node =
-        NodeRepository.get_node_by_parent_and_prev(get_node_id(parent_node), node.uuid)
+        NodeRepository.get_node_by_parent_and_prev(
+          node.outline_node_container_id,
+          get_node_id(parent_node),
+          node.uuid
+        )
 
       new_next_node =
-        NodeRepository.get_node_by_parent_and_prev(new_parent_id, new_prev_id)
+        NodeRepository.get_node_by_parent_and_prev(
+          node.outline_node_container_id,
+          new_parent_id,
+          new_prev_id
+        )
 
       {:ok, node} = NodeRepository.move_node_if(node, new_parent_id, new_prev_id)
 

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -72,7 +72,8 @@ defmodule Radiator.Outline do
       parent_node = find_parent_node(prev_node, parent_id)
 
       # find Node which has been previously connected to prev_node
-      next_node = NodeRepository.get_next_node(outline_node_container_id, prev_id, get_node_id(parent_node))
+      next_node =
+        NodeRepository.get_next_node(outline_node_container_id, prev_id, get_node_id(parent_node))
 
       with true <- parent_and_prev_consistent?(parent_node, prev_node),
            true <- container_valid?(outline_node_container_id, parent_node, prev_node),
@@ -82,7 +83,11 @@ defmodule Radiator.Outline do
              |> NodeRepository.create_node(),
            {:ok, _node_to_move} <-
              NodeRepository.move_node_if(next_node, get_node_id(parent_node), node.uuid) do
-        %NodeRepoResult{node: node, next: get_node_result_info(next_node), outline_node_container_id: outline_node_container_id}
+        %NodeRepoResult{
+          node: node,
+          next: get_node_result_info(next_node),
+          outline_node_container_id: outline_node_container_id
+        }
       else
         false ->
           Repo.rollback("Insert node failed. Parent and prev node are not consistent.")
@@ -432,11 +437,25 @@ defmodule Radiator.Outline do
   def get_node_id(nil), do: nil
   def get_node_id(%Node{} = node), do: node.uuid
 
-  defp container_valid?(outline_node_container_id, %Node{outline_node_container_id: outline_node_container_id}, %Node{outline_node_container_id: outline_node_container_id}),
-    do: true
+  defp container_valid?(
+         outline_node_container_id,
+         %Node{outline_node_container_id: outline_node_container_id},
+         %Node{outline_node_container_id: outline_node_container_id}
+       ),
+       do: true
 
-  defp container_valid?(outline_node_container_id, %Node{outline_node_container_id: outline_node_container_id}, nil), do: true
-  defp container_valid?(outline_node_container_id, nil, %Node{outline_node_container_id: outline_node_container_id}), do: true
+  defp container_valid?(
+         outline_node_container_id,
+         %Node{outline_node_container_id: outline_node_container_id},
+         nil
+       ),
+       do: true
+
+  defp container_valid?(outline_node_container_id, nil, %Node{
+         outline_node_container_id: outline_node_container_id
+       }),
+       do: true
+
   defp container_valid?(_outline_node_container_id, nil, nil), do: true
   defp container_valid?(_outline_node_container_id, _parent_node, _prev_node), do: false
 

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -48,6 +48,7 @@ defmodule Radiator.Outline do
 
   @doc """
     Returns a list of all child nodes.
+    TODO: check wether we really need this function
     """
     def list_nodes_by_container_sorted(container_id) do
       NodeRepository.list_nodes_by_node_container(container_id)

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -8,7 +8,7 @@ defmodule Radiator.Outline.NodeRepoResult do
     :old_next,
     :next,
     :children,
-    :episode_id
+    :outline_node_container_id
   ]
 end
 
@@ -21,8 +21,6 @@ defmodule Radiator.Outline do
   alias Radiator.Outline.NodeRepoResult
   alias Radiator.Outline.NodeRepository
   alias Radiator.Outline.Validations, as: NodeValidator
-  alias Radiator.Podcast
-  alias Radiator.Podcast.Episode
   alias Radiator.Repo
 
   require Logger
@@ -49,17 +47,6 @@ defmodule Radiator.Outline do
   end
 
   @doc """
-  Returns a list of all child nodes.
-  """
-  def list_nodes_by_episode_sorted(episode_id) do
-    episode_id
-    |> NodeRepository.list_nodes_by_episode()
-    |> Enum.group_by(& &1.parent_id)
-    |> Enum.map(fn {_parent_id, children} -> order_sibling_nodes(children) end)
-    |> List.flatten()
-  end
-
-  @doc """
   Inserts a node.
 
   ## Examples
@@ -76,27 +63,26 @@ defmodule Radiator.Outline do
   # if a previous node is given, the new node will be inserted after the previous node
   # if no parent is given, the new node will be inserted as a root node
   # if no previous node is given, the new node will be inserted as the first child of the parent node
-  def insert_node(%{"show_id" => _show_id} = attrs) do
+  def insert_node(%{"outline_node_container_id" => outline_node_container_id} = attrs) do
     Repo.transaction(fn ->
       prev_id = attrs["prev_id"]
       parent_id = attrs["parent_id"]
-      episode_id = attrs["episode_id"]
 
       prev_node = NodeRepository.get_node_if(prev_id)
       parent_node = find_parent_node(prev_node, parent_id)
 
       # find Node which has been previously connected to prev_node
-      next_node = NodeRepository.get_next_node(episode_id, prev_id, get_node_id(parent_node))
+      next_node = NodeRepository.get_next_node(outline_node_container_id, prev_id, get_node_id(parent_node))
 
       with true <- parent_and_prev_consistent?(parent_node, prev_node),
-           true <- episode_valid?(episode_id, parent_node, prev_node),
+           true <- container_valid?(outline_node_container_id, parent_node, prev_node),
            {:ok, node} <-
              attrs
              |> set_parent_id_if(parent_node)
              |> NodeRepository.create_node(),
            {:ok, _node_to_move} <-
              NodeRepository.move_node_if(next_node, get_node_id(parent_node), node.uuid) do
-        %NodeRepoResult{node: node, next: get_node_result_info(next_node), episode_id: episode_id}
+        %NodeRepoResult{node: node, next: get_node_result_info(next_node), outline_node_container_id: outline_node_container_id}
       else
         false ->
           Repo.rollback("Insert node failed. Parent and prev node are not consistent.")
@@ -106,14 +92,6 @@ defmodule Radiator.Outline do
           Repo.rollback("Insert node failed. Unknown error")
       end
     end)
-  end
-
-  def insert_node(%{"episode_id" => episode_id} = attrs) do
-    %Episode{show_id: show_id} = Podcast.get_episode!(episode_id)
-
-    attrs
-    |> Map.put("show_id", show_id)
-    |> insert_node()
   end
 
   @doc """
@@ -329,10 +307,9 @@ defmodule Radiator.Outline do
 
         node_attrs = %{
           "content" => new_node_content,
-          "episode_id" => node.episode_id,
+          "outline_node_container_id" => node.outline_node_container_id,
           "parent_id" => node.parent_id,
-          "prev_id" => node.uuid,
-          "outline_node_container_id" => node.outline_node_container_id
+          "prev_id" => node.uuid
         }
 
         {:ok, %NodeRepoResult{node: new_node, next: old_next_node}} =
@@ -342,7 +319,7 @@ defmodule Radiator.Outline do
          %NodeRepoResult{
            node: updated_node,
            next: new_node,
-           episode_id: updated_node.episode_id,
+           outline_node_container_id: updated_node.outline_node_container_id,
            old_next: get_node_result_info(old_next_node)
          }}
     end
@@ -391,7 +368,7 @@ defmodule Radiator.Outline do
       node: deleted_node,
       next: get_node_result_info(updated_next_node),
       children: all_children ++ recursive_deleted_children,
-      episode_id: node.episode_id
+      outline_node_container_id: node.outline_node_container_id
     }
   end
 
@@ -455,13 +432,13 @@ defmodule Radiator.Outline do
   def get_node_id(nil), do: nil
   def get_node_id(%Node{} = node), do: node.uuid
 
-  defp episode_valid?(episode_id, %Node{episode_id: episode_id}, %Node{episode_id: episode_id}),
+  defp container_valid?(outline_node_container_id, %Node{outline_node_container_id: outline_node_container_id}, %Node{outline_node_container_id: outline_node_container_id}),
     do: true
 
-  defp episode_valid?(episode_id, %Node{episode_id: episode_id}, nil), do: true
-  defp episode_valid?(episode_id, nil, %Node{episode_id: episode_id}), do: true
-  defp episode_valid?(_episode_id, nil, nil), do: true
-  defp episode_valid?(_episode_id, _parent_node, _prev_node), do: false
+  defp container_valid?(outline_node_container_id, %Node{outline_node_container_id: outline_node_container_id}, nil), do: true
+  defp container_valid?(outline_node_container_id, nil, %Node{outline_node_container_id: outline_node_container_id}), do: true
+  defp container_valid?(_outline_node_container_id, nil, nil), do: true
+  defp container_valid?(_outline_node_container_id, _parent_node, _prev_node), do: false
 
   defp set_parent_id_if(attrs, nil), do: attrs
   defp set_parent_id_if(attrs, %Node{uuid: uuid}), do: Map.put_new(attrs, "parent_id", uuid)
@@ -478,7 +455,7 @@ defmodule Radiator.Outline do
   defp do_move_node(node, new_prev_id, new_parent_id, prev_node, parent_node) do
     node_repo_result = %NodeRepoResult{
       node: get_node_result_info(node),
-      episode_id: node.episode_id
+      outline_node_container_id: node.outline_node_container_id
     }
 
     Repo.transaction(fn ->
@@ -573,10 +550,10 @@ defmodule Radiator.Outline do
   defp do_move_up(%Node{}, nil), do: {:error, :no_previous_node}
 
   defp do_move_up(
-         %Node{episode_id: episode_id, parent_id: parent_id} = node,
+         %Node{outline_node_container_id: outline_node_container_id, parent_id: parent_id} = node,
          %Node{} = prev_node
        ) do
-    next_node = NodeRepository.get_next_node(episode_id, node.uuid, parent_id)
+    next_node = NodeRepository.get_next_node(outline_node_container_id, node.uuid, parent_id)
 
     {:ok, updated_node} = NodeRepository.move_node_if(node, parent_id, prev_node.prev_id)
     {:ok, updated_prev_node} = NodeRepository.move_node_if(prev_node, parent_id, node.uuid)
@@ -584,7 +561,7 @@ defmodule Radiator.Outline do
 
     %NodeRepoResult{
       node: get_node_result_info(updated_node),
-      episode_id: episode_id,
+      outline_node_container_id: outline_node_container_id,
       old_prev: get_node_result_info(updated_prev_node),
       old_next: get_node_result_info(updated_next_node)
     }
@@ -593,7 +570,7 @@ defmodule Radiator.Outline do
   defp do_move_down(%Node{}, nil), do: {:error, :no_next_node}
 
   defp do_move_down(
-         %Node{episode_id: episode_id, parent_id: parent_id} = node,
+         %Node{outline_node_container_id: outline_node_container_id, parent_id: parent_id} = node,
          %Node{} = next_node
        ) do
     new_next_node = NodeRepository.get_next_node(next_node)
@@ -606,7 +583,7 @@ defmodule Radiator.Outline do
 
     %NodeRepoResult{
       node: get_node_result_info(updated_node),
-      episode_id: episode_id,
+      outline_node_container_id: outline_node_container_id,
       old_next: get_node_result_info(updated_next_node),
       next: get_node_result_info(updated_new_next_node)
     }

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -48,7 +48,6 @@ defmodule Radiator.Outline do
 
   @doc """
   Returns a list of all child nodes.
-  TODO: check wether we really need this function
   """
   def list_nodes_by_container_sorted(container_id) do
     NodeRepository.list_nodes_by_node_container(container_id)

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -47,6 +47,14 @@ defmodule Radiator.Outline do
   end
 
   @doc """
+    Returns a list of all child nodes.
+    """
+    def list_nodes_by_container_sorted(container_id) do
+      NodeRepository.list_nodes_by_node_container(container_id)
+    end
+
+
+  @doc """
   Inserts a node.
 
   ## Examples

--- a/lib/radiator/outline/command_processor.ex
+++ b/lib/radiator/outline/command_processor.ex
@@ -131,13 +131,24 @@ defmodule Radiator.Outline.CommandProcessor do
            selection: selection
          } = command
        ) do
-    {:ok, %NodeRepoResult{node: node, next: next, outline_node_container_id: outline_node_container_id, old_next: old_next}} =
+    {:ok,
+     %NodeRepoResult{
+       node: node,
+       next: next,
+       outline_node_container_id: outline_node_container_id,
+       old_next: old_next
+     }} =
       node_id
       |> Outline.split_node(selection)
 
     # broadcast two events
     handle_insert_node_result(
-      {:ok, %NodeRepoResult{node: next, next: old_next, outline_node_container_id: outline_node_container_id}},
+      {:ok,
+       %NodeRepoResult{
+         node: next,
+         next: old_next,
+         outline_node_container_id: outline_node_container_id
+       }},
       command
     )
 
@@ -147,7 +158,12 @@ defmodule Radiator.Outline.CommandProcessor do
   end
 
   defp handle_insert_node_result(
-         {:ok, %NodeRepoResult{node: node, next: next, outline_node_container_id: outline_node_container_id}},
+         {:ok,
+          %NodeRepoResult{
+            node: node,
+            next: next,
+            outline_node_container_id: outline_node_container_id
+          }},
          command
        ) do
     %NodeInsertedEvent{

--- a/lib/radiator/outline/command_processor.ex
+++ b/lib/radiator/outline/command_processor.ex
@@ -112,7 +112,7 @@ defmodule Radiator.Outline.CommandProcessor do
 
         %NodeDeletedEvent{
           node: result.node,
-          episode_id: result.episode_id,
+          outline_node_container_id: result.outline_node_container_id,
           event_id: command.event_id,
           user_id: command.user_id,
           children: result.children,
@@ -131,13 +131,13 @@ defmodule Radiator.Outline.CommandProcessor do
            selection: selection
          } = command
        ) do
-    {:ok, %NodeRepoResult{node: node, next: next, episode_id: episode_id, old_next: old_next}} =
+    {:ok, %NodeRepoResult{node: node, next: next, outline_node_container_id: outline_node_container_id, old_next: old_next}} =
       node_id
       |> Outline.split_node(selection)
 
     # broadcast two events
     handle_insert_node_result(
-      {:ok, %NodeRepoResult{node: next, next: old_next, episode_id: episode_id}},
+      {:ok, %NodeRepoResult{node: next, next: old_next, outline_node_container_id: outline_node_container_id}},
       command
     )
 
@@ -147,7 +147,7 @@ defmodule Radiator.Outline.CommandProcessor do
   end
 
   defp handle_insert_node_result(
-         {:ok, %NodeRepoResult{node: node, next: next, episode_id: episode_id}},
+         {:ok, %NodeRepoResult{node: node, next: next, outline_node_container_id: outline_node_container_id}},
          command
        ) do
     %NodeInsertedEvent{
@@ -155,7 +155,7 @@ defmodule Radiator.Outline.CommandProcessor do
       event_id: command.event_id,
       user_id: command.user_id,
       next: next,
-      episode_id: episode_id
+      outline_node_container_id: outline_node_container_id
     }
     |> EventStore.persist_event()
     |> Dispatch.broadcast()
@@ -181,7 +181,7 @@ defmodule Radiator.Outline.CommandProcessor do
       event_id: command.event_id,
       next: result.next,
       children: result.children,
-      episode_id: result.episode_id
+      outline_node_container_id: result.outline_node_container_id
     }
     |> EventStore.persist_event()
     |> Dispatch.broadcast()
@@ -200,7 +200,7 @@ defmodule Radiator.Outline.CommandProcessor do
       content: node.content,
       user_id: command.user_id,
       event_id: command.event_id,
-      episode_id: node.episode_id
+      outline_node_container_id: node.outline_node_container_id
     }
     |> EventStore.persist_event()
     |> Dispatch.broadcast()

--- a/lib/radiator/outline/dispatch.ex
+++ b/lib/radiator/outline/dispatch.ex
@@ -69,8 +69,8 @@ defmodule Radiator.Outline.Dispatch do
     if Application.get_env(:radiator, :tree_consistency_validator, false) do
       :ok =
         event
-        |> Event.episode_id()
-        |> Validations.validate_tree_for_episode()
+        |> Event.outline_node_container_id()
+        |> Validations.validate_tree_for_outline_node_container()
     end
 
     Phoenix.PubSub.broadcast(Radiator.PubSub, "events", event)

--- a/lib/radiator/outline/event.ex
+++ b/lib/radiator/outline/event.ex
@@ -25,7 +25,7 @@ defmodule Radiator.Outline.Event do
   def payload(%NodeDeletedEvent{} = event) do
     %{
       node: event.node,
-      episode_id: event.episode_id,
+      outline_node_container_id: event.outline_node_container_id,
       children: event.children,
       next: event.next
     }
@@ -45,5 +45,5 @@ defmodule Radiator.Outline.Event do
   def event_type(%NodeDeletedEvent{} = _event), do: "NodeDeletedEvent"
   def event_type(%NodeMovedEvent{} = _event), do: "NodeMovedEvent"
 
-  def episode_id(%{episode_id: episode_id}), do: episode_id
+  def outline_node_container_id(%{outline_node_container_id: outline_node_container_id}), do: outline_node_container_id
 end

--- a/lib/radiator/outline/event.ex
+++ b/lib/radiator/outline/event.ex
@@ -45,5 +45,6 @@ defmodule Radiator.Outline.Event do
   def event_type(%NodeDeletedEvent{} = _event), do: "NodeDeletedEvent"
   def event_type(%NodeMovedEvent{} = _event), do: "NodeMovedEvent"
 
-  def outline_node_container_id(%{outline_node_container_id: outline_node_container_id}), do: outline_node_container_id
+  def outline_node_container_id(%{outline_node_container_id: outline_node_container_id}),
+    do: outline_node_container_id
 end

--- a/lib/radiator/outline/event/node_content_changed_event.ex
+++ b/lib/radiator/outline/event/node_content_changed_event.ex
@@ -1,5 +1,5 @@
 defmodule Radiator.Outline.Event.NodeContentChangedEvent do
   @moduledoc false
 
-  defstruct [:event_id, :node_id, :content, :user_id, :episode_id]
+  defstruct [:event_id, :node_id, :content, :user_id, :outline_node_container_id]
 end

--- a/lib/radiator/outline/event/node_deleted_event.ex
+++ b/lib/radiator/outline/event/node_deleted_event.ex
@@ -1,4 +1,4 @@
 defmodule Radiator.Outline.Event.NodeDeletedEvent do
   @moduledoc false
-  defstruct [:event_id, :node, :user_id, :children, :next, :episode_id]
+  defstruct [:event_id, :node, :user_id, :children, :next, :outline_node_container_id]
 end

--- a/lib/radiator/outline/event/node_inserted_event.ex
+++ b/lib/radiator/outline/event/node_inserted_event.ex
@@ -1,5 +1,5 @@
 defmodule Radiator.Outline.Event.NodeInsertedEvent do
   @moduledoc false
 
-  defstruct [:event_id, :node, :user_id, :next, :episode_id, :content]
+  defstruct [:event_id, :node, :user_id, :next, :outline_node_container_id, :content]
 end

--- a/lib/radiator/outline/event/node_moved_event.ex
+++ b/lib/radiator/outline/event/node_moved_event.ex
@@ -7,7 +7,7 @@ defmodule Radiator.Outline.Event.NodeMovedEvent do
     :old_prev,
     :old_next,
     :next,
-    :episode_id,
+    :outline_node_container_id,
     :children
   ]
 end

--- a/lib/radiator/outline/node.ex
+++ b/lib/radiator/outline/node.ex
@@ -6,7 +6,6 @@ defmodule Radiator.Outline.Node do
   import Ecto.Changeset
   alias Radiator.Outline.Node
   alias Radiator.Outline.NodeContainer
-  alias Radiator.Podcast.{Episode, Show}
   alias Radiator.Resources.Url
 
   @derive {Jason.Encoder, only: [:uuid, :content, :creator_id, :parent_id, :prev_id]}
@@ -21,8 +20,6 @@ defmodule Radiator.Outline.Node do
 
     belongs_to :outline_node_container, NodeContainer
 
-    belongs_to :episode, Episode
-    belongs_to :show, Show
     belongs_to :parent, Node, references: :uuid, type: Ecto.UUID
     belongs_to :prev, Node, references: :uuid, type: Ecto.UUID
     has_many :urls, Url, foreign_key: :node_id
@@ -40,11 +37,9 @@ defmodule Radiator.Outline.Node do
     |> cast(attributes, [
       :uuid,
       :content,
-      :episode_id,
       :creator_id,
       :parent_id,
       :prev_id,
-      :show_id,
       :outline_node_container_id
     ])
     |> put_uuid()

--- a/lib/radiator/outline/node_repository.ex
+++ b/lib/radiator/outline/node_repository.ex
@@ -152,16 +152,16 @@ defmodule Radiator.Outline.NodeRepository do
   Gets a single node defined by the given prev_id and parent_id.
   Returns `nil` if the Node cannot be found.
   ## Examples
-            iex> get_node_by_parent_and_prev("5adf3b360fb0", "380d56cf")
+            iex> get_node_by_parent_and_prev(23, "5adf3b360fb0", "380d56cf")
             nil
 
-            iex> get_node_by_parent_and_prev("5e3f5a0422a4", "b78a976d")
+            iex> get_node_by_parent_and_prev(42, "5e3f5a0422a4", "b78a976d")
             %Node{uuid: "33b2a1dac9b1", parent_id: "5e3f5a0422a4", prev_id: "b78a976d"}
   """
-  def get_node_by_parent_and_prev(parent_id, prev_id) do
+  def get_node_by_parent_and_prev(container_id, parent_id, prev_id) do
     Node
-    |> where_prev_node_equals(prev_id)
-    |> where_parent_node_equals(parent_id)
+    |> where_prev_node_equals(container_id, prev_id)
+    |> where_parent_node_equals(container_id, parent_id)
     |> Repo.one()
   end
 

--- a/lib/radiator/outline/node_repository.ex
+++ b/lib/radiator/outline/node_repository.ex
@@ -247,8 +247,8 @@ defmodule Radiator.Outline.NodeRepository do
   def get_next_node(outline_node_container_id, prev_id, parent_id) do
     Node
     |> where(outline_node_container_id: ^outline_node_container_id)
-    |> where_prev_node_equals(prev_id)
-    |> where_parent_node_equals(parent_id)
+    |> where_prev_node_equals(outline_node_container_id, prev_id)
+    |> where_parent_node_equals(outline_node_container_id, parent_id)
     |> Repo.one()
   end
 
@@ -399,11 +399,28 @@ defmodule Radiator.Outline.NodeRepository do
     {:ok, tree}
   end
 
-  defp where_prev_node_equals(node, nil), do: where(node, [n], is_nil(n.prev_id))
-  defp where_prev_node_equals(node, prev_id), do: where(node, [n], n.prev_id == ^prev_id)
+  defp where_prev_node_equals(node, outline_node_container_id, nil) do
+    node
+    |> where([n], is_nil(n.prev_id))
+    |> where([n], n.outline_node_container_id == ^outline_node_container_id)
+  end
+  defp where_prev_node_equals(node, outline_node_container_id, prev_id)do
+    node
+    |> where([n], n.prev_id == ^prev_id)
+    |> where([n], n.outline_node_container_id == ^outline_node_container_id)
+  end
 
-  defp where_parent_node_equals(node, nil), do: where(node, [n], is_nil(n.parent_id))
-  defp where_parent_node_equals(node, parent_id), do: where(node, [n], n.parent_id == ^parent_id)
+  defp where_parent_node_equals(node, outline_node_container_id, nil) do
+    node
+    |> where([n], is_nil(n.parent_id))
+    |> where([n], n.outline_node_container_id == ^outline_node_container_id)
+  end
+
+  defp where_parent_node_equals(node, outline_node_container_id, parent_id) do
+    node
+    |> where([n], n.parent_id == ^parent_id)
+    |> where([n], n.outline_node_container_id == ^outline_node_container_id)
+  end
 
   defp binaray_uuid_to_ecto_uuid(nil), do: nil
 

--- a/lib/radiator/outline/node_repository.ex
+++ b/lib/radiator/outline/node_repository.ex
@@ -59,17 +59,16 @@ defmodule Radiator.Outline.NodeRepository do
 
   @doc """
   Returns the list of nodes for an episode.
-
+  TODO should not be dependend on Outline module
   ## Examples
 
       iex> list_nodes(123)
       [%Node{}, ...]
 
   """
-
-  def list_nodes_by_episode(episode_id) do
+  def list_nodes_by_node_container(outline_node_container_id) do
     Node
-    |> where([p], p.episode_id == ^episode_id)
+    |> where([p], p.outline_node_container_id == ^outline_node_container_id)
     |> Repo.all()
     |> Enum.group_by(& &1.parent_id)
     |> Enum.map(fn {_parent_id, children} -> Radiator.Outline.order_sibling_nodes(children) end)
@@ -81,13 +80,13 @@ defmodule Radiator.Outline.NodeRepository do
 
   ## Examples
 
-      iex> count_nodes_by_episode(123)
+      iex> count_nodes_by_outline_node_container(123)
       3
 
   """
-  def count_nodes_by_episode(episode_id) do
+  def count_nodes_by_outline_node_container(outline_node_container_id) do
     Node
-    |> where([p], p.episode_id == ^episode_id)
+    |> where([p], p.outline_node_container_id == ^outline_node_container_id)
     |> Repo.aggregate(:count)
   end
 
@@ -223,15 +222,15 @@ defmodule Radiator.Outline.NodeRepository do
         iex> get_next_node(%Node{prev_id: 42})
         %Node{uuid: 42}
   """
-  def get_next_node(%Node{episode_id: episode_id, uuid: node_id, parent_id: parent_id}) do
-    get_next_node(episode_id, node_id, parent_id)
+  def get_next_node(%Node{outline_node_container_id: outline_node_container_id, uuid: node_id, parent_id: parent_id}) do
+    get_next_node(outline_node_container_id, node_id, parent_id)
   end
 
   @doc """
   get_next_node/3
   Returns the next node of a node defined by episode, previd and parent_id in the outline tree.
 
-  Since the previous id and the parent id of a node might be nil, we need to pass the episode_id
+  Since the previous id and the parent id of a node might be nil, we need to pass the outline_node_container_id
   to find the correct node.
 
   ## Examples
@@ -239,11 +238,11 @@ defmodule Radiator.Outline.NodeRepository do
         nil
 
         iex> get_next_node(42, "33b2a1dac9b1", "9d76aad4")
-        %Node{episode_id: 42, prev_id: "33b2a1dac9b1", parent_id: "9d76aad4"}
+        %Node{outline_node_container_id: 42, prev_id: "33b2a1dac9b1", parent_id: "9d76aad4"}
   """
-  def get_next_node(episode_id, prev_id, parent_id) do
+  def get_next_node(outline_node_container_id, prev_id, parent_id) do
     Node
-    |> where(episode_id: ^episode_id)
+    |> where(outline_node_container_id: ^outline_node_container_id)
     |> where_prev_node_equals(prev_id)
     |> where_parent_node_equals(parent_id)
     |> Repo.one()
@@ -325,7 +324,7 @@ defmodule Radiator.Outline.NodeRepository do
   WITH RECURSIVE node_tree AS (
         SELECT uuid, content, parent_id, prev_id, 0 AS level
         FROM outline_nodes
-        WHERE episode_id = ?::integer and parent_id is NULL
+        WHERE outline_node_container_id = ?::integer and parent_id is NULL
      UNION ALL
         SELECT outline_nodes.uuid, outline_nodes.content, outline_nodes.parent_id, outline_nodes.prev_id, node_tree.level + 1
         FROM outline_nodes
@@ -333,13 +332,13 @@ defmodule Radiator.Outline.NodeRepository do
   )
   SELECT * FROM node_tree;
   """
-  def get_node_tree(nil), do: {:error, "episode_id is nil"}
+  def get_node_tree(nil), do: {:error, "outline_node_container_id is nil"}
 
-  def get_node_tree(episode_id) do
+  def get_node_tree(outline_node_container_id) do
     node_tree_initial_query =
       Node
       |> where([n], is_nil(n.parent_id))
-      |> where([n], n.episode_id == ^episode_id)
+      |> where([n], n.outline_node_container_id == ^outline_node_container_id)
       |> select([n], %{
         uuid: n.uuid,
         content: n.content,
@@ -389,7 +388,7 @@ defmodule Radiator.Outline.NodeRepository do
           parent_id: binaray_uuid_to_ecto_uuid(parent_id),
           prev_id: binaray_uuid_to_ecto_uuid(prev_id),
           level: level,
-          episode_id: episode_id
+          outline_node_container_id: outline_node_container_id
         }
       end)
 

--- a/lib/radiator/outline/node_repository.ex
+++ b/lib/radiator/outline/node_repository.ex
@@ -404,7 +404,8 @@ defmodule Radiator.Outline.NodeRepository do
     |> where([n], is_nil(n.prev_id))
     |> where([n], n.outline_node_container_id == ^outline_node_container_id)
   end
-  defp where_prev_node_equals(node, outline_node_container_id, prev_id)do
+
+  defp where_prev_node_equals(node, outline_node_container_id, prev_id) do
     node
     |> where([n], n.prev_id == ^prev_id)
     |> where([n], n.outline_node_container_id == ^outline_node_container_id)

--- a/lib/radiator/outline/node_repository.ex
+++ b/lib/radiator/outline/node_repository.ex
@@ -222,7 +222,11 @@ defmodule Radiator.Outline.NodeRepository do
         iex> get_next_node(%Node{prev_id: 42})
         %Node{uuid: 42}
   """
-  def get_next_node(%Node{outline_node_container_id: outline_node_container_id, uuid: node_id, parent_id: parent_id}) do
+  def get_next_node(%Node{
+        outline_node_container_id: outline_node_container_id,
+        uuid: node_id,
+        parent_id: parent_id
+      }) do
     get_next_node(outline_node_container_id, node_id, parent_id)
   end
 

--- a/lib/radiator/outline/validations.ex
+++ b/lib/radiator/outline/validations.ex
@@ -42,10 +42,10 @@ defmodule Radiator.Outline.Validations do
   Validates a tree for an episode.
   Returns :ok if the tree is valid
   """
-  def validate_tree_for_episode(episode_id) do
-    {:ok, tree_nodes} = NodeRepository.get_node_tree(episode_id)
+  def validate_tree_for_outline_node_container(outline_node_container_id) do
+    {:ok, tree_nodes} = NodeRepository.get_node_tree(outline_node_container_id)
 
-    if Enum.count(tree_nodes) == NodeRepository.count_nodes_by_episode(episode_id) do
+    if Enum.count(tree_nodes) == NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id) do
       validate_tree_nodes(tree_nodes)
     else
       {:error, :node_count_not_consistent}

--- a/lib/radiator/outline/validations.ex
+++ b/lib/radiator/outline/validations.ex
@@ -45,7 +45,8 @@ defmodule Radiator.Outline.Validations do
   def validate_tree_for_outline_node_container(outline_node_container_id) do
     {:ok, tree_nodes} = NodeRepository.get_node_tree(outline_node_container_id)
 
-    if Enum.count(tree_nodes) == NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id) do
+    if Enum.count(tree_nodes) ==
+         NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id) do
       validate_tree_nodes(tree_nodes)
     else
       {:error, :node_count_not_consistent}

--- a/lib/radiator/podcast.ex
+++ b/lib/radiator/podcast.ex
@@ -453,6 +453,13 @@ defmodule Radiator.Podcast do
   """
   def get_episode!(id), do: Repo.get!(Episode, id)
 
+  def get_episode_by_container_id(container_id) do
+    Repo.one(
+      from e in Episode,
+        where: e.outline_node_container_id == ^container_id
+    )
+  end
+
   @doc """
     Finds the newest (TODO: not published ) episode for a show.
     Returns %Episode{} or `nil` and expects an id of the show.

--- a/lib/radiator/podcast/show.ex
+++ b/lib/radiator/podcast/show.ex
@@ -8,7 +8,6 @@ defmodule Radiator.Podcast.Show do
   import Ecto.Changeset
 
   alias Radiator.Accounts.User
-  alias Radiator.Outline.Node
   alias Radiator.Outline.NodeContainer
   alias Radiator.Podcast.{Episode, Network}
 
@@ -22,7 +21,6 @@ defmodule Radiator.Podcast.Show do
     belongs_to :outline_node_container, NodeContainer
 
     has_many(:episodes, Episode)
-    has_many(:outline_nodes, Node)
     many_to_many(:hosts, User, join_through: "show_hosts")
 
     timestamps(type: :utc_datetime)

--- a/lib/radiator/resources.ex
+++ b/lib/radiator/resources.ex
@@ -24,8 +24,7 @@ defmodule Radiator.Resources do
   def list_urls_by_episode(episode_id) do
     query =
       from u in Url,
-        join: n in assoc(u, :node),
-        where: n.episode_id == ^episode_id
+        where: u.episode_id == ^episode_id
 
     Repo.all(query)
   end

--- a/lib/radiator/resources/node_changed_worker.ex
+++ b/lib/radiator/resources/node_changed_worker.ex
@@ -3,6 +3,7 @@ defmodule Radiator.Resources.NodeChangedWorker do
   job to extract urls from content and persist URLs
   """
   alias __MODULE__
+  alias Radiator.EpisodeOutliner
   alias Radiator.NodeAnalyzer
   alias Radiator.Outline.NodeRepository
   alias Radiator.Resources
@@ -18,13 +19,15 @@ defmodule Radiator.Resources.NodeChangedWorker do
     analyzers = [Radiator.NodeAnalyzer.UrlAnalyzer]
     node = NodeRepository.get_node!(node_id)
 
+    episode_id = EpisodeOutliner.episode_id_for_node(node)
+
     url_attributes =
       node
       |> NodeAnalyzer.do_analyze(analyzers)
       |> Enum.map(fn attributes ->
         attributes
         |> Map.put(:node_id, node_id)
-        |> Map.put(:episode_id, node.episode_id)
+        |> Map.put(:episode_id, episode_id)
       end)
 
     _created_urls = Resources.rebuild_node_urls(node_id, url_attributes)

--- a/lib/radiator/resources/url.ex
+++ b/lib/radiator/resources/url.ex
@@ -39,7 +39,7 @@ defmodule Radiator.Resources.Url do
   def changeset(url, attrs) do
     url
     |> cast(attrs, [:url, :start_bytes, :size_bytes, :node_id, :episode_id])
-    |> validate_required([:url, :start_bytes, :size_bytes, :node_id, :episode_id])
+    |> validate_required([:url, :start_bytes, :size_bytes, :node_id])
     |> cast_embed(:meta_data, with: &MetaData.changeset/2)
   end
 end

--- a/lib/radiator/resources/url.ex
+++ b/lib/radiator/resources/url.ex
@@ -39,7 +39,7 @@ defmodule Radiator.Resources.Url do
   def changeset(url, attrs) do
     url
     |> cast(attrs, [:url, :start_bytes, :size_bytes, :node_id, :episode_id])
-    |> validate_required([:url, :start_bytes, :size_bytes, :node_id])
+    |> validate_required([:url, :start_bytes, :size_bytes, :node_id, :episode_id])
     |> cast_embed(:meta_data, with: &MetaData.changeset/2)
   end
 end

--- a/lib/radiator_web/live/components/outline.ex
+++ b/lib/radiator_web/live/components/outline.ex
@@ -94,8 +94,8 @@ defmodule RadiatorWeb.Components.Outline do
     |> reply(:ok)
   end
 
-  def update(%{episode_id: id} = assigns, socket) do
-    nodes = EpisodeOutliner.list_nodes_by_episode_sorted(id)
+  def update(%{container_id: id} = assigns, socket) do
+    nodes = Outliner.list_nodes_by_container_sorted(id)
     node_forms = Enum.map(nodes, &to_change_form(&1, %{}))
 
     socket

--- a/lib/radiator_web/live/components/outline.ex
+++ b/lib/radiator_web/live/components/outline.ex
@@ -2,7 +2,6 @@ defmodule RadiatorWeb.Components.Outline do
   @moduledoc false
   use RadiatorWeb, :live_component
 
-  alias Radiator.EpisodeOutliner
   alias Radiator.Outline
   alias Radiator.Outline.Dispatch
 
@@ -95,7 +94,7 @@ defmodule RadiatorWeb.Components.Outline do
   end
 
   def update(%{container_id: id} = assigns, socket) do
-    nodes = Outliner.list_nodes_by_container_sorted(id)
+    nodes = Outline.list_nodes_by_container_sorted(id)
     node_forms = Enum.map(nodes, &to_change_form(&1, %{}))
 
     socket

--- a/lib/radiator_web/live/components/outline.ex
+++ b/lib/radiator_web/live/components/outline.ex
@@ -2,6 +2,7 @@ defmodule RadiatorWeb.Components.Outline do
   @moduledoc false
   use RadiatorWeb, :live_component
 
+  alias Radiator.EpisodeOutliner
   alias Radiator.Outline
   alias Radiator.Outline.Dispatch
 
@@ -94,7 +95,7 @@ defmodule RadiatorWeb.Components.Outline do
   end
 
   def update(%{episode_id: id} = assigns, socket) do
-    nodes = Outline.list_nodes_by_episode_sorted(id)
+    nodes = EpisodeOutliner.list_nodes_by_episode_sorted(id)
     node_forms = Enum.map(nodes, &to_change_form(&1, %{}))
 
     socket

--- a/lib/radiator_web/live/episode_live/index.html.heex
+++ b/lib/radiator_web/live/episode_live/index.html.heex
@@ -74,7 +74,7 @@
       <.live_component
         id={"outline-#{@selected_episode.id}"}
         module={RadiatorWeb.Components.Outline}
-        episode_id={@selected_episode.id}
+        container_id={@selected_episode.outline_node_container_id}
         user_id={@current_user.id}
         user={@current_user}
       />

--- a/priv/repo/migrations/20241222121424_remove_shows_and_episodes_from_nodes.exs
+++ b/priv/repo/migrations/20241222121424_remove_shows_and_episodes_from_nodes.exs
@@ -1,0 +1,10 @@
+defmodule Radiator.Repo.Migrations.RemoveShowsAndEpisodesFromNodes do
+  use Ecto.Migration
+
+  def change do
+    alter table(:outline_nodes) do
+      remove :episode_id, references(:episodes, on_delete: :nothing)
+      remove :show_id, references(:shows, on_delete: :nothing)
+    end
+  end
+end

--- a/test/radiator/outline/command_processor_test.exs
+++ b/test/radiator/outline/command_processor_test.exs
@@ -19,12 +19,17 @@ defmodule Radiator.Outline.CommandProcessorTest do
         "episode_id" => episode.id
       }
 
-      num_nodes = NodeRepository.count_nodes_by_outline_node_container(episode.outline_node_container_id)
+      num_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(episode.outline_node_container_id)
+
       command = Command.build("insert_node", attributes, user.id, event_id)
       CommandProcessor.handle_events([command], 0, nil)
 
       # assert a node has been created
-      assert num_nodes + 1 == NodeRepository.count_nodes_by_outline_node_container(episode.outline_node_container_id)
+      assert num_nodes + 1 ==
+               NodeRepository.count_nodes_by_outline_node_container(
+                 episode.outline_node_container_id
+               )
     end
 
     test "insert_node creates and stores an event", %{

--- a/test/radiator/outline/command_processor_test.exs
+++ b/test/radiator/outline/command_processor_test.exs
@@ -19,12 +19,12 @@ defmodule Radiator.Outline.CommandProcessorTest do
         "episode_id" => episode.id
       }
 
-      num_nodes = NodeRepository.count_nodes_by_episode(episode.id)
+      num_nodes = NodeRepository.count_nodes_by_outline_node_container(episode.outline_node_container_id)
       command = Command.build("insert_node", attributes, user.id, event_id)
       CommandProcessor.handle_events([command], 0, nil)
 
       # assert a node has been created
-      assert num_nodes + 1 == NodeRepository.count_nodes_by_episode(episode.id)
+      assert num_nodes + 1 == NodeRepository.count_nodes_by_outline_node_container(episode.outline_node_container_id)
     end
 
     test "insert_node creates and stores an event", %{

--- a/test/radiator/outline/node_repository_test.exs
+++ b/test/radiator/outline/node_repository_test.exs
@@ -65,13 +65,13 @@ defmodule Radiator.Outline.NodeRepositoryTest do
     end
   end
 
-  describe "list_nodes_by_episode/1" do
+  describe "list_nodes_by_node_container/1" do
     test "list_nodes/1 returns only nodes of this episode" do
       node1 = node_fixture()
       node2 = node_fixture()
 
-      assert NodeRepository.list_nodes_by_episode(node1.episode_id) == [node1]
-      assert NodeRepository.list_nodes_by_episode(node2.episode_id) == [node2]
+      assert NodeRepository.list_nodes_by_node_container(node1.outline_node_container_id) == [node1]
+      assert NodeRepository.list_nodes_by_node_container(node2.outline_node_container_id) == [node2]
     end
   end
 
@@ -159,10 +159,10 @@ defmodule Radiator.Outline.NodeRepositoryTest do
     setup :complex_node_fixture
 
     test "returns all nodes from a episode", %{parent_node: parent_node} do
-      episode_id = parent_node.episode_id
-      assert {:ok, tree} = NodeRepository.get_node_tree(episode_id)
+      outline_node_container_id = parent_node.outline_node_container_id
+      assert {:ok, tree} = NodeRepository.get_node_tree(outline_node_container_id)
 
-      all_nodes = NodeRepository.list_nodes_by_episode(episode_id)
+      all_nodes = NodeRepository.list_nodes_by_node_container(outline_node_container_id)
 
       assert Enum.count(tree) == Enum.count(all_nodes)
 
@@ -172,19 +172,19 @@ defmodule Radiator.Outline.NodeRepositoryTest do
       end)
     end
 
-    test "does not return a node from another episode", %{
+    test "does not return a node from another container", %{
       parent_node: parent_node
     } do
-      episode_id = parent_node.episode_id
+      outline_node_container_id = parent_node.outline_node_container_id
       other_node = node_fixture(parent_id: nil, prev_id: nil, content: "other content")
-      assert other_node.episode_id != episode_id
-      {:ok, tree} = NodeRepository.get_node_tree(episode_id)
+      assert other_node.outline_node_container_id != outline_node_container_id
+      {:ok, tree} = NodeRepository.get_node_tree(outline_node_container_id)
       assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == []
     end
 
     test "returns nodes sorted by level", %{parent_node: parent_node} do
-      episode_id = parent_node.episode_id
-      {:ok, tree} = NodeRepository.get_node_tree(episode_id)
+      outline_node_container_id = parent_node.outline_node_container_id
+      {:ok, tree} = NodeRepository.get_node_tree(outline_node_container_id)
 
       Enum.reduce(tree, 0, fn node, current_level ->
         if node.parent_id != nil do
@@ -208,7 +208,7 @@ defmodule Radiator.Outline.NodeRepositoryTest do
       nested_node_2: nested_node_2,
       parent_node: parent_node
     } do
-      {:ok, tree} = NodeRepository.get_node_tree(parent_node.episode_id)
+      {:ok, tree} = NodeRepository.get_node_tree(parent_node.outline_node_container_id)
       assert_level_for_node(tree, parent_node, 0)
       assert_level_for_node(tree, node_1, 1)
       assert_level_for_node(tree, node_2, 1)
@@ -223,13 +223,13 @@ defmodule Radiator.Outline.NodeRepositoryTest do
     test "tree can have more than one parent node", %{
       parent_node: parent_node
     } do
-      episode_id = parent_node.episode_id
+      outline_node_container_id = parent_node.outline_node_container_id
 
       other_parent_node =
         node_fixture(
           parent_id: nil,
           prev_id: parent_node.uuid,
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           content: "also a parent"
         )
 
@@ -237,11 +237,11 @@ defmodule Radiator.Outline.NodeRepositoryTest do
         node_fixture(
           parent_id: nil,
           prev_id: other_parent_node.uuid,
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           content: "even another root element"
         )
 
-      {:ok, tree} = NodeRepository.get_node_tree(parent_node.episode_id)
+      {:ok, tree} = NodeRepository.get_node_tree(parent_node.outline_node_container_id)
       assert_level_for_node(tree, parent_node, 0)
       assert_level_for_node(tree, other_parent_node, 0)
       assert_level_for_node(tree, third_parent_node, 0)

--- a/test/radiator/outline/node_repository_test.exs
+++ b/test/radiator/outline/node_repository_test.exs
@@ -70,8 +70,13 @@ defmodule Radiator.Outline.NodeRepositoryTest do
       node1 = node_fixture()
       node2 = node_fixture()
 
-      assert NodeRepository.list_nodes_by_node_container(node1.outline_node_container_id) == [node1]
-      assert NodeRepository.list_nodes_by_node_container(node2.outline_node_container_id) == [node2]
+      assert NodeRepository.list_nodes_by_node_container(node1.outline_node_container_id) == [
+               node1
+             ]
+
+      assert NodeRepository.list_nodes_by_node_container(node2.outline_node_container_id) == [
+               node2
+             ]
     end
   end
 

--- a/test/radiator/outline/node_test.exs
+++ b/test/radiator/outline/node_test.exs
@@ -13,14 +13,14 @@ defmodule Radiator.Outline.NodeTest do
       uuid = Ecto.UUID.generate()
 
       node1 =
-        %Node{uuid: uuid, episode_id: episode.id}
+        %Node{uuid: uuid, outline_node_container_id: episode.outline_node_container_id}
         |> Node.insert_changeset(%{content: "some content"})
         |> Ecto.Changeset.apply_changes()
 
       assert node1.uuid == uuid
 
       node2 =
-        %Node{episode_id: episode.id}
+        %Node{outline_node_container_id: episode.outline_node_container_id}
         |> Node.insert_changeset(%{content: "some other content"})
         |> Ecto.Changeset.apply_changes()
 
@@ -34,8 +34,6 @@ defmodule Radiator.Outline.NodeTest do
 
       attributes = %{
         "uuid" => uuid,
-        "episode_id" => episode.id,
-        "show_id" => episode.show_id,
         "outline_node_container_id" => episode.outline_node_container_id,
         "content" => "Node Content"
       }
@@ -48,7 +46,6 @@ defmodule Radiator.Outline.NodeTest do
 
       attributes = %{
         "episode_id" => episode.id,
-        "show_id" => episode.show_id,
         "outline_node_container_id" => episode.outline_node_container_id,
         "content" => "Node Content"
       }
@@ -63,7 +60,6 @@ defmodule Radiator.Outline.NodeTest do
       attributes = %{
         "uuid" => "not-a-uuid",
         "episode_id" => episode.id,
-        "show_id" => episode.show_id,
         "outline_node_container_id" => episode.outline_node_container_id,
         "content" => "Node Content"
       }

--- a/test/radiator/outline/validations_test.exs
+++ b/test/radiator/outline/validations_test.exs
@@ -12,70 +12,62 @@ defmodule Radiator.Outline.ValidationsTest do
     setup :complex_node_fixture
 
     test "validates a tree", %{
-      node_1: %Node{episode_id: episode_id}
+      node_1: %Node{outline_node_container_id: outline_node_container_id}
     } do
-      assert :ok = Validations.validate_tree_for_episode(episode_id)
+      assert :ok = Validations.validate_tree_for_outline_node_container(outline_node_container_id)
     end
 
     test "a level might have different subtrees", %{
-      node_1: %Node{episode_id: episode_id, show_id: show_id} = node_1
+      node_1: %Node{outline_node_container_id: outline_node_container_id} = node_1
     } do
       {:ok, %Node{} = _nested_node} =
         %{
-          episode_id: episode_id,
-          show_id: show_id,
-          outline_node_container_id: node_1.outline_node_container_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: node_1.uuid,
           prev_id: nil,
           content: "child of node 1"
         }
         |> NodeRepository.create_node()
 
-      assert :ok = Validations.validate_tree_for_episode(episode_id)
+      assert :ok = Validations.validate_tree_for_outline_node_container(outline_node_container_id)
     end
 
     test "when two nodes share the same prev_id the tree is invalid", %{
-      node_2: %Node{episode_id: episode_id, show_id: show_id} = node_2
+      node_2: %Node{outline_node_container_id: outline_node_container_id} = node_2
     } do
       {:ok, %Node{} = _node_invalid} =
         %{
-          episode_id: episode_id,
-          show_id: show_id,
-          outline_node_container_id: node_2.outline_node_container_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: node_2.parent_id,
           prev_id: node_2.prev_id
         }
         |> NodeRepository.create_node()
 
       assert {:error, :prev_id_not_consistent} =
-               Validations.validate_tree_for_episode(episode_id)
+        Validations.validate_tree_for_outline_node_container(outline_node_container_id)
     end
 
     test "when a nodes has a non connected prev_id the tree is invalid", %{
-      node_2: %Node{episode_id: episode_id, show_id: show_id} = node_2
+      node_2: %Node{outline_node_container_id: outline_node_container_id} = node_2
     } do
       {:ok, %Node{} = _node_invalid} =
         %{
-          episode_id: episode_id,
-          show_id: show_id,
-          outline_node_container_id: node_2.outline_node_container_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: node_2.parent_id,
           prev_id: node_2.prev_id
         }
         |> NodeRepository.create_node()
 
       assert {:error, :prev_id_not_consistent} =
-               Validations.validate_tree_for_episode(episode_id)
+               Validations.validate_tree_for_outline_node_container(outline_node_container_id)
     end
 
     test "when a parent has two childs with prev_id nil the tree is invalid", %{
       nested_node_1:
-        %Node{episode_id: episode_id, parent_id: parent_id, show_id: show_id} = nested_node_1
+        %Node{outline_node_container_id: outline_node_container_id, parent_id: parent_id} = nested_node_1
     } do
       {:ok, %Node{} = _node_invalid} =
         %{
-          episode_id: episode_id,
-          show_id: show_id,
           outline_node_container_id: nested_node_1.outline_node_container_id,
           parent_id: parent_id,
           prev_id: nil,
@@ -84,24 +76,22 @@ defmodule Radiator.Outline.ValidationsTest do
         |> NodeRepository.create_node()
 
       assert {:error, :prev_id_not_consistent} =
-               Validations.validate_tree_for_episode(episode_id)
+               Validations.validate_tree_for_outline_node_container(outline_node_container_id)
     end
 
     test "a tree with a node where parent and prev are not consistent is invalid", %{
-      parent_node: %Node{episode_id: episode_id, show_id: show_id} = parent_node,
+      parent_node: %Node{outline_node_container_id: outline_node_container_id} = parent_node,
       nested_node_2: nested_node_2
     } do
       {:ok, %Node{} = _node_invalid} =
         %{
-          episode_id: episode_id,
-          show_id: show_id,
-          outline_node_container_id: nested_node_2.outline_node_container_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: parent_node.uuid,
           prev_id: nested_node_2.uuid
         }
         |> NodeRepository.create_node()
 
-      result = Validations.validate_tree_for_episode(episode_id)
+      result = Validations.validate_tree_for_outline_node_container(outline_node_container_id)
       assert {:error, :prev_id_not_consistent} = result
     end
   end

--- a/test/radiator/outline/validations_test.exs
+++ b/test/radiator/outline/validations_test.exs
@@ -44,7 +44,7 @@ defmodule Radiator.Outline.ValidationsTest do
         |> NodeRepository.create_node()
 
       assert {:error, :prev_id_not_consistent} =
-        Validations.validate_tree_for_outline_node_container(outline_node_container_id)
+               Validations.validate_tree_for_outline_node_container(outline_node_container_id)
     end
 
     test "when a nodes has a non connected prev_id the tree is invalid", %{
@@ -64,7 +64,8 @@ defmodule Radiator.Outline.ValidationsTest do
 
     test "when a parent has two childs with prev_id nil the tree is invalid", %{
       nested_node_1:
-        %Node{outline_node_container_id: outline_node_container_id, parent_id: parent_id} = nested_node_1
+        %Node{outline_node_container_id: outline_node_container_id, parent_id: parent_id} =
+          nested_node_1
     } do
       {:ok, %Node{} = _node_invalid} =
         %{

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -38,7 +38,7 @@ defmodule Radiator.OutlineTest do
     end
 
     test "tree of nodes" do
-      %{outline_node_container_id: outline_node_container_id, show_id: show_id} = episode_fixture()
+      %{outline_node_container_id: outline_node_container_id} = episode_fixture()
 
       nodes =
         [

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -192,23 +192,6 @@ defmodule Radiator.OutlineTest do
       assert new_node.prev_id == nested_node_1.uuid
     end
 
-    test "the show_id gets set - even if not given", %{
-      node_3: node_3,
-      nested_node_1: nested_node_1
-    } do
-      node_attrs = %{
-        "content" => "new node",
-        "outline_node_container_id" => node_3.outline_node_container_id,
-        "parent_id" => node_3.uuid,
-        "prev_id" => nested_node_1.uuid
-      }
-
-      {:ok, %{node: new_node}} = Outline.insert_node(node_attrs)
-
-      episode = Podcast.get_episode!(node_3.episode_id)
-      assert new_node.show_id == episode.show_id
-    end
-
     test "the next node - if existing - changes its prev_id and gets returned", %{
       node_2: node_2,
       node_3: node_3
@@ -817,7 +800,7 @@ defmodule Radiator.OutlineTest do
         Outline.split_node(node_1.uuid, {2, 3})
 
       assert node.uuid == node_1.uuid
-      assert node.episode_id == node_1.episode_id
+      assert node.outline_node_container_id == node_1.outline_node_container_id
       {new_content, _} = String.split_at(node_1.content, start)
       assert node.content == new_content
     end
@@ -1001,7 +984,7 @@ defmodule Radiator.OutlineTest do
     } do
       nested_node_3 =
         node_fixture(
-          episode_id: episode.id,
+          outline_node_container_id: episode.outline_node_container_id,
           parent_id: node_3.uuid,
           prev_id: nested_node_2.uuid,
           content: "nested_node_3"
@@ -1009,7 +992,7 @@ defmodule Radiator.OutlineTest do
 
       nested_node_4 =
         node_fixture(
-          episode_id: episode.id,
+          outline_node_container_id: episode.outline_node_container_id,
           parent_id: node_3.uuid,
           prev_id: nested_node_3.uuid,
           content: "nested_node_4"
@@ -1392,7 +1375,7 @@ defmodule Radiator.OutlineTest do
           content: "even another root element"
         )
 
-      tree = Outline.list_nodes_by_episode_sorted(parent_node.outline_node_container_id)
+      tree = Outline.list_nodes_by_container_sorted(parent_node.outline_node_container_id)
 
       num_nodes_without_parents =
         tree
@@ -1408,7 +1391,7 @@ defmodule Radiator.OutlineTest do
 
       node_1 =
         node_fixture(
-          episode_id: node_container.id,
+          outline_node_container_id: node_container.id,
           parent_id: nil,
           prev_id: nil,
           content: "node_1"
@@ -1416,7 +1399,7 @@ defmodule Radiator.OutlineTest do
 
       node_3 =
         node_fixture(
-          episode_id: node_container.id,
+          outline_node_container_id: node_container.id,
           parent_id: node_1.uuid,
           prev_id: nil,
           content: "node_3"
@@ -1424,7 +1407,7 @@ defmodule Radiator.OutlineTest do
 
       node_2 =
         node_fixture(
-          episode_id: node_container.id,
+          outline_node_container_id: node_container.id,
           parent_id: node_1.uuid,
           prev_id: node_3.uuid,
           content: "node_2"

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -1326,10 +1326,10 @@ defmodule Radiator.OutlineTest do
     setup :complex_node_fixture
 
     test "returns all nodes from a container", %{parent_node: parent_node} do
-      episode_id = parent_node.episode_id
-      tree = Outline.list_nodes_by_episode_sorted(episode_id)
+      outline_node_container_id = parent_node.outline_node_container_id
+      tree = Outline.list_nodes_by_container_sorted(outline_node_container_id)
 
-      all_nodes = NodeRepository.list_nodes_by_episode(episode_id)
+      all_nodes = NodeRepository.list_nodes_by_node_container(outline_node_container_id)
 
       assert Enum.count(tree) == Enum.count(all_nodes)
 
@@ -1342,23 +1342,23 @@ defmodule Radiator.OutlineTest do
     test "does not return a node from another container", %{
       parent_node: parent_node
     } do
-      episode_id = parent_node.episode_id
+      outline_node_container_id = parent_node.outline_node_container_id
       other_node = node_fixture(parent_id: nil, prev_id: nil, content: "other content")
-      assert other_node.episode_id != episode_id
-      tree = Outline.list_nodes_by_episode_sorted(episode_id)
+      assert other_node.outline_node_container_id != outline_node_container_id
+      tree = Outline.list_nodes_by_container_sorted(outline_node_container_id)
       assert Enum.filter(tree, fn n -> n.uuid == other_node.uuid end) == []
     end
 
     test "tree can have more than one parent node", %{
       parent_node: parent_node
     } do
-      episode_id = parent_node.episode_id
+      outline_node_container_id = parent_node.outline_node_container_id
 
       other_parent_node =
         node_fixture(
           parent_id: nil,
           prev_id: parent_node.uuid,
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           content: "also a parent"
         )
 
@@ -1366,11 +1366,11 @@ defmodule Radiator.OutlineTest do
         node_fixture(
           parent_id: nil,
           prev_id: other_parent_node.uuid,
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           content: "even another root element"
         )
 
-      tree = Outline.list_nodes_by_episode_sorted(parent_node.episode_id)
+      tree = Outline.list_nodes_by_episode_sorted(parent_node.outline_node_container_id)
 
       num_nodes_without_parents =
         tree
@@ -1381,14 +1381,13 @@ defmodule Radiator.OutlineTest do
   end
 
   describe "order_child_nodes/1" do
-    setup :complex_node_fixture
 
     test "get child nodes in correct order" do
-      episode = episode_fixture()
+      node_container = node_container_fixture()
 
       node_1 =
         node_fixture(
-          episode_id: episode.id,
+          episode_id: node_container.id,
           parent_id: nil,
           prev_id: nil,
           content: "node_1"
@@ -1396,7 +1395,7 @@ defmodule Radiator.OutlineTest do
 
       node_3 =
         node_fixture(
-          episode_id: episode.id,
+          episode_id: node_container.id,
           parent_id: node_1.uuid,
           prev_id: nil,
           content: "node_3"
@@ -1404,7 +1403,7 @@ defmodule Radiator.OutlineTest do
 
       node_2 =
         node_fixture(
-          episode_id: episode.id,
+          episode_id: node_container.id,
           parent_id: node_1.uuid,
           prev_id: node_3.uuid,
           content: "node_2"

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -149,6 +149,7 @@ defmodule Radiator.OutlineTest do
       episode: %{outline_node_container_id: node_container_id}
     } do
       count_nodes = NodeRepository.count_nodes_by_outline_node_container(node_container_id)
+
       node_attrs = %{
         "content" => "new node",
         "outline_node_container_id" => node_3.outline_node_container_id,
@@ -331,7 +332,11 @@ defmodule Radiator.OutlineTest do
       parent_node: parent_node
     } do
       bad_parent_node =
-        node_fixture(outline_node_container_id: parent_node.outline_node_container_id, parent_id: nil, prev_id: nil)
+        node_fixture(
+          outline_node_container_id: parent_node.outline_node_container_id,
+          parent_id: nil,
+          prev_id: nil
+        )
 
       node_attrs = %{
         "content" => "new node",
@@ -349,7 +354,10 @@ defmodule Radiator.OutlineTest do
       parent_node: parent_node,
       nested_node_1: nested_node_1
     } do
-      count_nodes = NodeRepository.count_nodes_by_outline_node_container(parent_node.outline_node_container_id)
+      count_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(
+          parent_node.outline_node_container_id
+        )
 
       {:ok, another_episode} =
         Podcast.create_episode(%{title: "current episode", show_id: episode.show_id, number: 23})
@@ -361,7 +369,12 @@ defmodule Radiator.OutlineTest do
       }
 
       {:error, _error_message} = Outline.insert_node(node_attrs)
-      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(parent_node.outline_node_container_id)
+
+      new_count_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(
+          parent_node.outline_node_container_id
+        )
+
       # count stays the same
       assert new_count_nodes == count_nodes
     end
@@ -1247,9 +1260,14 @@ defmodule Radiator.OutlineTest do
       node_6: node_6,
       episode: %{outline_node_container_id: outline_node_container_id}
     } do
-      count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
+      count_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
+
       assert %NodeRepoResult{} = Outline.remove_node(node_6)
-      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
+
+      new_count_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
+
       assert new_count_nodes == count_nodes - 1
     end
 
@@ -1258,10 +1276,14 @@ defmodule Radiator.OutlineTest do
       node_2: node_2,
       episode: %{outline_node_container_id: outline_node_container_id}
     } do
+      count_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
 
-      count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
       assert %NodeRepoResult{} = Outline.remove_node(node_1)
-      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
+
+      new_count_nodes =
+        NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
+
       assert new_count_nodes == count_nodes - 1
 
       node_2 = NodeRepository.get_node!(node_2.uuid)
@@ -1381,7 +1403,6 @@ defmodule Radiator.OutlineTest do
   end
 
   describe "order_child_nodes/1" do
-
     test "get child nodes in correct order" do
       node_container = node_container_fixture()
 

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -349,7 +349,7 @@ defmodule Radiator.OutlineTest do
       parent_node: parent_node,
       nested_node_1: nested_node_1
     } do
-      count_nodes = NodeRepository.count_nodes_by_episode(parent_node.episode_id)
+      count_nodes = NodeRepository.count_nodes_by_outline_node_container(parent_node.outline_node_container_id)
 
       {:ok, another_episode} =
         Podcast.create_episode(%{title: "current episode", show_id: episode.show_id, number: 23})
@@ -361,7 +361,7 @@ defmodule Radiator.OutlineTest do
       }
 
       {:error, _error_message} = Outline.insert_node(node_attrs)
-      new_count_nodes = NodeRepository.count_nodes_by_episode(parent_node.episode_id)
+      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(parent_node.outline_node_container_id)
       # count stays the same
       assert new_count_nodes == count_nodes
     end
@@ -1245,23 +1245,23 @@ defmodule Radiator.OutlineTest do
 
     test "works for last element in list", %{
       node_6: node_6,
-      episode: %{id: episode_id}
+      episode: %{outline_node_container_id: outline_node_container_id}
     } do
-      count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
+      count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
       assert %NodeRepoResult{} = Outline.remove_node(node_6)
-      new_count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
+      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
       assert new_count_nodes == count_nodes - 1
     end
 
     test "works for first element in list", %{
       node_1: node_1,
       node_2: node_2,
-      episode: %{id: episode_id}
+      episode: %{outline_node_container_id: outline_node_container_id}
     } do
 
-      count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
+      count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
       assert %NodeRepoResult{} = Outline.remove_node(node_1)
-      new_count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
+      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(outline_node_container_id)
       assert new_count_nodes == count_nodes - 1
 
       node_2 = NodeRepository.get_node!(node_2.uuid)
@@ -1322,10 +1322,10 @@ defmodule Radiator.OutlineTest do
     end
   end
 
-  describe "list_nodes_by_episode_sorted/1" do
+  describe "list_nodes_by_container_sorted/1" do
     setup :complex_node_fixture
 
-    test "returns all nodes from a episode", %{parent_node: parent_node} do
+    test "returns all nodes from a container", %{parent_node: parent_node} do
       episode_id = parent_node.episode_id
       tree = Outline.list_nodes_by_episode_sorted(episode_id)
 
@@ -1339,7 +1339,7 @@ defmodule Radiator.OutlineTest do
       end)
     end
 
-    test "does not return a node from another episode", %{
+    test "does not return a node from another container", %{
       parent_node: parent_node
     } do
       episode_id = parent_node.episode_id

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -13,22 +13,22 @@ defmodule Radiator.OutlineTest do
 
   describe "generate nodes from template" do
     test "single node" do
-      %{id: episode_id} = episode_fixture()
+      %{outline_node_container_id: outline_node_container_id} = episode_fixture()
 
-      assert %Node{} = node = "node-1" |> node_tree_fixture(%{episode_id: episode_id})
-      assert [%Node{}] = list = ["node-1"] |> node_tree_fixture(%{episode_id: episode_id})
+      assert %Node{} = node = "node-1" |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
+      assert [%Node{}] = list = ["node-1"] |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
 
-      assert %{content: "node-1", parent_id: nil, prev_id: nil, episode_id: ^episode_id} = node
-      assert [%{content: "node-1", parent_id: nil, prev_id: nil, episode_id: ^episode_id}] = list
+      assert %{content: "node-1", parent_id: nil, prev_id: nil, outline_node_container_id: ^outline_node_container_id} = node
+      assert [%{content: "node-1", parent_id: nil, prev_id: nil, outline_node_container_id: ^outline_node_container_id}] = list
     end
 
     test "list of nodes" do
-      %{id: episode_id} = episode_fixture()
+      %{outline_node_container_id: outline_node_container_id} = episode_fixture()
 
-      nodes = ["node-1", "node-2", "node-3"] |> node_tree_fixture(%{episode_id: episode_id})
+      nodes = ["node-1", "node-2", "node-3"] |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
 
       assert length(nodes) == 3
-      assert Enum.all?(nodes, &match?(%Node{episode_id: ^episode_id}, &1))
+      assert Enum.all?(nodes, &match?(%Node{outline_node_container_id: ^outline_node_container_id}, &1))
 
       assert [
                %{uuid: uuid_1, content: "node-1", parent_id: nil, prev_id: nil},
@@ -38,7 +38,7 @@ defmodule Radiator.OutlineTest do
     end
 
     test "tree of nodes" do
-      %{id: episode_id, show_id: show_id} = episode_fixture()
+      %{outline_node_container_id: outline_node_container_id, show_id: show_id} = episode_fixture()
 
       nodes =
         [
@@ -58,10 +58,10 @@ defmodule Radiator.OutlineTest do
            ]},
           "node-5"
         ]
-        |> node_tree_fixture(%{episode_id: episode_id, show_id: show_id})
+        |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
 
       assert length(nodes) == 13
-      assert Enum.all?(nodes, &match?(%Node{episode_id: ^episode_id}, &1))
+      assert Enum.all?(nodes, &match?(%Node{outline_node_container_id: ^outline_node_container_id}, &1))
 
       assert [
                %{uuid: uuid_1, content: "node-1", parent_id: nil, prev_id: nil},
@@ -106,7 +106,6 @@ defmodule Radiator.OutlineTest do
     test "node can be inserted after another node", %{node_3: node_3, node_4: node_4} do
       node_attrs = %{
         "content" => "node 3.1",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.parent_id,
         "prev_id" => node_3.uuid
@@ -129,7 +128,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_1.uuid
@@ -149,7 +147,6 @@ defmodule Radiator.OutlineTest do
 
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_1.uuid
@@ -166,7 +163,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_1.uuid
@@ -182,7 +178,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_1.uuid
@@ -198,7 +193,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_1.uuid
@@ -216,7 +210,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_2.episode_id,
         "prev_id" => node_2.uuid,
         "outline_node_container_id" => node_2.outline_node_container_id
       }
@@ -232,7 +225,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "prev_id" => nested_node_1.uuid
       }
@@ -248,7 +240,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_1.uuid
@@ -268,7 +259,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid,
         "prev_id" => nested_node_2.uuid
@@ -288,7 +278,6 @@ defmodule Radiator.OutlineTest do
     } do
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => node_3.episode_id,
         "outline_node_container_id" => node_3.outline_node_container_id,
         "parent_id" => node_3.uuid
       }
@@ -308,7 +297,6 @@ defmodule Radiator.OutlineTest do
 
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => parent_node.episode_id,
         "outline_node_container_id" => parent_node.outline_node_container_id
       }
 
@@ -326,7 +314,6 @@ defmodule Radiator.OutlineTest do
       # new node cannot be inserted at level 1 and wants the lined in level 2
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => parent_node.episode_id,
         "outline_node_container_id" => parent_node.outline_node_container_id,
         "parent_id" => parent_node.uuid,
         "prev_id" => nested_node_1.uuid
@@ -344,7 +331,6 @@ defmodule Radiator.OutlineTest do
 
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => parent_node.episode_id,
         "outline_node_container_id" => parent_node.outline_node_container_id,
         "parent_id" => parent_node.uuid,
         "prev_id" => bad_parent_node.uuid
@@ -366,7 +352,6 @@ defmodule Radiator.OutlineTest do
 
       node_attrs = %{
         "content" => "new node",
-        "episode_id" => another_episode.id,
         "outline_node_container_id" => another_episode.outline_node_container_id,
         "prev_id" => nested_node_1.uuid
       }

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -61,7 +61,11 @@ defmodule Radiator.OutlineTest do
         |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
 
       assert length(nodes) == 13
-      assert Enum.all?(nodes, &match?(%Node{outline_node_container_id: ^outline_node_container_id}, &1))
+
+      assert Enum.all?(
+               nodes,
+               &match?(%Node{outline_node_container_id: ^outline_node_container_id}, &1)
+             )
 
       assert [
                %{uuid: uuid_1, content: "node-1", parent_id: nil, prev_id: nil},

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -145,10 +145,10 @@ defmodule Radiator.OutlineTest do
 
     test "creates a new node in the tree", %{
       node_3: node_3,
-      nested_node_1: nested_node_1
+      nested_node_1: nested_node_1,
+      episode: %{outline_node_container_id: node_container_id}
     } do
-      count_nodes = NodeRepository.count_nodes_by_episode(node_3.episode_id)
-
+      count_nodes = NodeRepository.count_nodes_by_outline_node_container(node_container_id)
       node_attrs = %{
         "content" => "new node",
         "outline_node_container_id" => node_3.outline_node_container_id,
@@ -157,7 +157,7 @@ defmodule Radiator.OutlineTest do
       }
 
       Outline.insert_node(node_attrs)
-      new_count_nodes = NodeRepository.count_nodes_by_episode(node_3.episode_id)
+      new_count_nodes = NodeRepository.count_nodes_by_outline_node_container(node_container_id)
       assert new_count_nodes == count_nodes + 1
     end
 
@@ -331,7 +331,7 @@ defmodule Radiator.OutlineTest do
       parent_node: parent_node
     } do
       bad_parent_node =
-        node_fixture(episode_id: parent_node.episode_id, parent_id: nil, prev_id: nil)
+        node_fixture(outline_node_container_id: parent_node.outline_node_container_id, parent_id: nil, prev_id: nil)
 
       node_attrs = %{
         "content" => "new node",
@@ -1244,9 +1244,9 @@ defmodule Radiator.OutlineTest do
     end
 
     test "works for last element in list", %{
-      node_6: node_6
+      node_6: node_6,
+      episode: %{id: episode_id}
     } do
-      episode_id = node_6.episode_id
       count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
       assert %NodeRepoResult{} = Outline.remove_node(node_6)
       new_count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
@@ -1255,9 +1255,9 @@ defmodule Radiator.OutlineTest do
 
     test "works for first element in list", %{
       node_1: node_1,
-      node_2: node_2
+      node_2: node_2,
+      episode: %{id: episode_id}
     } do
-      episode_id = node_1.episode_id
 
       count_nodes = NodeRepository.count_nodes_by_episode(episode_id)
       assert %NodeRepoResult{} = Outline.remove_node(node_1)
@@ -1499,7 +1499,8 @@ defmodule Radiator.OutlineTest do
 
     test "list_outline_node_containers/0 returns all outline_node_containers" do
       node_container = node_container_fixture()
-      assert Outline.list_outline_node_containers() == [node_container]
+      all_containers = Outline.list_outline_node_containers()
+      assert Enum.find(all_containers, fn nc -> nc.id == node_container.id end) == node_container
     end
 
     test "get_node_container!/1 returns the node_container with given id" do

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -15,20 +15,46 @@ defmodule Radiator.OutlineTest do
     test "single node" do
       %{outline_node_container_id: outline_node_container_id} = episode_fixture()
 
-      assert %Node{} = node = "node-1" |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
-      assert [%Node{}] = list = ["node-1"] |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
+      assert %Node{} =
+               node =
+               "node-1"
+               |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
 
-      assert %{content: "node-1", parent_id: nil, prev_id: nil, outline_node_container_id: ^outline_node_container_id} = node
-      assert [%{content: "node-1", parent_id: nil, prev_id: nil, outline_node_container_id: ^outline_node_container_id}] = list
+      assert [%Node{}] =
+               list =
+               ["node-1"]
+               |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
+
+      assert %{
+               content: "node-1",
+               parent_id: nil,
+               prev_id: nil,
+               outline_node_container_id: ^outline_node_container_id
+             } = node
+
+      assert [
+               %{
+                 content: "node-1",
+                 parent_id: nil,
+                 prev_id: nil,
+                 outline_node_container_id: ^outline_node_container_id
+               }
+             ] = list
     end
 
     test "list of nodes" do
       %{outline_node_container_id: outline_node_container_id} = episode_fixture()
 
-      nodes = ["node-1", "node-2", "node-3"] |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
+      nodes =
+        ["node-1", "node-2", "node-3"]
+        |> node_tree_fixture(%{outline_node_container_id: outline_node_container_id})
 
       assert length(nodes) == 3
-      assert Enum.all?(nodes, &match?(%Node{outline_node_container_id: ^outline_node_container_id}, &1))
+
+      assert Enum.all?(
+               nodes,
+               &match?(%Node{outline_node_container_id: ^outline_node_container_id}, &1)
+             )
 
       assert [
                %{uuid: uuid_1, content: "node-1", parent_id: nil, prev_id: nil},

--- a/test/radiator/resources_test.exs
+++ b/test/radiator/resources_test.exs
@@ -15,7 +15,7 @@ defmodule Radiator.ResourcesbTest do
     setup :set_up_single_url
 
     test "returns all urls of an episode", %{episode: episode, node: node} do
-      url = url_fixture(node_id: node.uuid)
+      url = url_fixture(node_id: node.uuid, episode_id: episode.id)
       assert Resources.list_urls_by_episode(episode.id) == [url]
     end
   end

--- a/test/radiator/resources_test.exs
+++ b/test/radiator/resources_test.exs
@@ -52,7 +52,10 @@ defmodule Radiator.ResourcesbTest do
     test "rebuilds all urls for a node" do
       url_text = "https://hexdocs.pm"
       episode = PodcastFixtures.episode_fixture()
-      node = OutlineFixtures.node_fixture(outline_node_container_id: episode.outline_node_container_id)
+
+      node =
+        OutlineFixtures.node_fixture(outline_node_container_id: episode.outline_node_container_id)
+
       old_url = url_fixture(node_id: node.uuid)
       episode_id = episode.id
 
@@ -118,6 +121,7 @@ defmodule Radiator.ResourcesbTest do
 
   def set_up_single_url(_) do
     episode = PodcastFixtures.episode_fixture()
+
     node =
       OutlineFixtures.node_fixture(outline_node_container_id: episode.outline_node_container_id)
 

--- a/test/radiator/resources_test.exs
+++ b/test/radiator/resources_test.exs
@@ -5,6 +5,7 @@ defmodule Radiator.ResourcesbTest do
   import Radiator.ResourcesFixtures
 
   alias Radiator.OutlineFixtures
+  alias Radiator.PodcastFixtures
   alias Radiator.Resources
   alias Radiator.Resources.Url
 
@@ -50,9 +51,10 @@ defmodule Radiator.ResourcesbTest do
 
     test "rebuilds all urls for a node" do
       url_text = "https://hexdocs.pm"
-      node = OutlineFixtures.node_fixture()
+      episode = PodcastFixtures.episode_fixture()
+      node = OutlineFixtures.node_fixture(outline_node_container_id: episode.outline_node_container_id)
       old_url = url_fixture(node_id: node.uuid)
-      episode_id = node.episode_id
+      episode_id = episode.id
 
       assert [%Url{url: ^url_text, start_bytes: 42, size_bytes: 42, episode_id: ^episode_id}] =
                Resources.rebuild_node_urls(node.uuid, [
@@ -115,11 +117,9 @@ defmodule Radiator.ResourcesbTest do
   end
 
   def set_up_single_url(_) do
+    episode = PodcastFixtures.episode_fixture()
     node =
-      OutlineFixtures.node_fixture()
-      |> Repo.preload([:episode])
-
-    episode = node.episode
+      OutlineFixtures.node_fixture(outline_node_container_id: episode.outline_node_container_id)
 
     {:ok, episode: episode, node: node}
   end

--- a/test/radiator_web/controllers/api/outline_controller_test.exs
+++ b/test/radiator_web/controllers/api/outline_controller_test.exs
@@ -45,9 +45,10 @@ defmodule RadiatorWeb.Api.OutlineControllerTest do
 
       %{"uuid" => uuid} = json_response(conn, 200)
 
-      episode_id = Podcast.get_current_episode_for_show(show_id).id
+      outline_node_container_id =
+        Podcast.get_current_episode_for_show(show_id).outline_node_container_id
 
-      assert %{content: "new node content", episode_id: ^episode_id} =
+      assert %{content: "new node content", outline_node_container_id: ^outline_node_container_id} =
                NodeRepository.get_node!(uuid)
     end
 

--- a/test/radiator_web/live/outline_live_test.exs
+++ b/test/radiator_web/live/outline_live_test.exs
@@ -12,7 +12,9 @@ defmodule RadiatorWeb.OutlineLiveTest do
     setup %{conn: conn} do
       user = user_fixture()
       show = show_fixture()
-      %{id: episode_id, outline_node_container_id: outline_node_container_id} = episode_fixture(%{show_id: show.id})
+
+      %{id: episode_id, outline_node_container_id: outline_node_container_id} =
+        episode_fixture(%{show_id: show.id})
 
       node_1 =
         node_fixture(

--- a/test/radiator_web/live/outline_live_test.exs
+++ b/test/radiator_web/live/outline_live_test.exs
@@ -12,11 +12,11 @@ defmodule RadiatorWeb.OutlineLiveTest do
     setup %{conn: conn} do
       user = user_fixture()
       show = show_fixture()
-      %{id: episode_id} = episode_fixture(%{show_id: show.id})
+      %{id: episode_id, outline_node_container_id: outline_node_container_id} = episode_fixture(%{show_id: show.id})
 
       node_1 =
         node_fixture(
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: nil,
           prev_id: nil,
           content: "node_1"
@@ -24,7 +24,7 @@ defmodule RadiatorWeb.OutlineLiveTest do
 
       node_2 =
         node_fixture(
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: nil,
           prev_id: node_1.uuid,
           content: "node_2"
@@ -32,7 +32,7 @@ defmodule RadiatorWeb.OutlineLiveTest do
 
       node_2_1 =
         node_fixture(
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: node_2.uuid,
           prev_id: nil,
           content: "node_2_1"
@@ -40,7 +40,7 @@ defmodule RadiatorWeb.OutlineLiveTest do
 
       node_3 =
         node_fixture(
-          episode_id: episode_id,
+          outline_node_container_id: outline_node_container_id,
           parent_id: nil,
           prev_id: node_2.uuid,
           content: "node_3"

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -65,8 +65,6 @@ defmodule Radiator.DataCase do
     episode = PodcastFixtures.episode_fixture()
 
     attrs = %{
-      episode_id: episode.id,
-      show_id: episode.show_id,
       outline_node_container_id: episode.outline_node_container_id
     }
 
@@ -82,8 +80,6 @@ defmodule Radiator.DataCase do
     episode = PodcastFixtures.episode_fixture()
 
     attrs = %{
-      episode_id: episode.id,
-      show_id: episode.show_id,
       outline_node_container_id: episode.outline_node_container_id
     }
 
@@ -102,8 +98,6 @@ defmodule Radiator.DataCase do
 
     node_1 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: nil,
         prev_id: nil,
@@ -112,8 +106,6 @@ defmodule Radiator.DataCase do
 
     node_2 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: node_1.uuid,
         prev_id: nil,
@@ -131,8 +123,6 @@ defmodule Radiator.DataCase do
 
     parent_node =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: nil,
         prev_id: nil,
@@ -141,8 +131,6 @@ defmodule Radiator.DataCase do
 
     node_1 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: parent_node.uuid,
         prev_id: nil,
@@ -151,8 +139,6 @@ defmodule Radiator.DataCase do
 
     node_2 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: parent_node.uuid,
         prev_id: node_1.uuid,
@@ -161,8 +147,6 @@ defmodule Radiator.DataCase do
 
     node_3 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: parent_node.uuid,
         prev_id: node_2.uuid,
@@ -171,8 +155,6 @@ defmodule Radiator.DataCase do
 
     node_4 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: parent_node.uuid,
         prev_id: node_3.uuid,
@@ -181,8 +163,6 @@ defmodule Radiator.DataCase do
 
     node_5 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: parent_node.uuid,
         prev_id: node_4.uuid,
@@ -191,8 +171,6 @@ defmodule Radiator.DataCase do
 
     node_6 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: parent_node.uuid,
         prev_id: node_5.uuid,
@@ -201,8 +179,6 @@ defmodule Radiator.DataCase do
 
     nested_node_1 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: node_3.uuid,
         prev_id: nil,
@@ -211,8 +187,6 @@ defmodule Radiator.DataCase do
 
     nested_node_2 =
       node_fixture(
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id,
         parent_id: node_3.uuid,
         prev_id: nested_node_1.uuid,

--- a/test/support/fixtures/event_store_fixtures.ex
+++ b/test/support/fixtures/event_store_fixtures.ex
@@ -68,10 +68,17 @@ defmodule Radiator.EventStoreFixtures do
 
   def node_moved_event_fixture(user_id: user_id) do
     node = OutlineFixtures.node_fixture()
-    _parent = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
-    _prev = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+
+    _parent =
+      OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+
+    _prev =
+      OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+
     next = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
-    old_next = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+
+    old_next =
+      OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
 
     old_prev =
       OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)

--- a/test/support/fixtures/event_store_fixtures.ex
+++ b/test/support/fixtures/event_store_fixtures.ex
@@ -35,7 +35,7 @@ defmodule Radiator.EventStoreFixtures do
 
   def node_inserted_event_fixture(user_id: user_id) do
     node = OutlineFixtures.node_fixture()
-    next = OutlineFixtures.node_fixture(episode_id: node.episode_id)
+    next = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
 
     %NodeInsertedEvent{
       node: node,
@@ -68,13 +68,13 @@ defmodule Radiator.EventStoreFixtures do
 
   def node_moved_event_fixture(user_id: user_id) do
     node = OutlineFixtures.node_fixture()
-    _parent = OutlineFixtures.node_fixture(episode_id: node.episode_id)
-    _prev = OutlineFixtures.node_fixture(episode_id: node.episode_id)
-    next = OutlineFixtures.node_fixture(episode_id: node.episode_id)
-    old_next = OutlineFixtures.node_fixture(episode_id: node.episode_id)
+    _parent = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+    _prev = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+    next = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
+    old_next = OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
 
     old_prev =
-      OutlineFixtures.node_fixture(episode_id: node.episode_id)
+      OutlineFixtures.node_fixture(outline_node_container_id: node.outline_node_container_id)
 
     %NodeMovedEvent{
       node: %{uuid: node.uuid, parent_id: node.parent_id, prev_id: node.prev_id},

--- a/test/support/fixtures/outline_fixtures.ex
+++ b/test/support/fixtures/outline_fixtures.ex
@@ -19,8 +19,6 @@ defmodule Radiator.OutlineFixtures do
       attrs
       |> Enum.into(%{
         content: "some content",
-        episode_id: episode.id,
-        show_id: episode.show_id,
         outline_node_container_id: episode.outline_node_container_id
       })
       |> NodeRepository.create_node()


### PR DESCRIPTION
To loose the coupling between these. So they can be used independently from shows and episodes