### PR TITLE
doc: fix typos

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 elixir 1.18.3-otp-27
-erlang 27.3
+erlang 27.3.4
 node 24.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Just as in the **subject**, use the imperative, present tense: "change" not "cha
 ### Footer
 
 The footer should contain one line for each github issue it closes.
-If the commit contains**Breaking Changes**, the description of them should start with the word `BREAKING CHANGE: `. The rest of the footer can be freely formatted to repesent it.
+If the commit contains**Breaking Changes**, the description of them should start with the word `BREAKING CHANGE: `. The rest of the footer can be freely formatted to represent it.
 
 ### Revert
 

--- a/lib/radiator/accounts/raindrop.ex
+++ b/lib/radiator/accounts/raindrop.ex
@@ -150,7 +150,7 @@ defmodule Radiator.Accounts.Raindrop do
 
   @doc """
   Finds the user_id associated with a given show_id through Raindrop mappings.
-  This is only a temporal hack, should be replaced because this might be ambigous in the future!!
+  This is only a temporal hack, should be replaced because this might be ambiguous in the future!!
 
   ## Examples
 

--- a/lib/radiator/episode_outliner.ex
+++ b/lib/radiator/episode_outliner.ex
@@ -17,7 +17,7 @@ defmodule Radiator.EpisodeOutliner do
   end
 
   @doc """
-    Not yet sure wether we want this
+    Not yet sure whether we want this
     Note: Will crash when episode does not exist
   """
   def container_with_episode_id(episode_id) do

--- a/lib/radiator/job.ex
+++ b/lib/radiator/job.ex
@@ -19,7 +19,7 @@ defmodule Radiator.Job do
    This function requires to return either `:ok` or `:error`.
    Arguments are optional and can be passed in as a keyword list with the keyword `arguments`.
    Please note that order matters here and the worker function must accept the arguments as single arguments.
-   The keyword list is only for beeing more clear about the arguments.
+   The keyword list is only for being more clear about the arguments.
    If a job errors it will be retried up to `max_retries` times.
    It defaults to 3 but can be set via the keyword `max_retries`
 

--- a/lib/radiator/outline.ex
+++ b/lib/radiator/outline.ex
@@ -560,7 +560,7 @@ defmodule Radiator.Outline do
 
   @doc """
   Removes a node from the tree and deletes it from the repository.
-  Recursivly deletes all children if there are some.
+  Recursively deletes all children if there are some.
   ## Examples
 
       iex> remove_node(node)

--- a/lib/radiator/outline/command/delete_node_command.ex
+++ b/lib/radiator/outline/command/delete_node_command.ex
@@ -1,6 +1,6 @@
 defmodule Radiator.Outline.Command.DeleteNodeCommand do
   @moduledoc """
-  Command to remove a node from the outline and delete it permantly.
+  Command to remove a node from the outline and delete it permanently.
   """
   @type t() :: %__MODULE__{
           event_id: binary(),

--- a/lib/radiator/outline/node_repository.ex
+++ b/lib/radiator/outline/node_repository.ex
@@ -45,7 +45,7 @@ defmodule Radiator.Outline.NodeRepository do
 
   @doc """
   Returns the list of nodes for an container.
-  TODO should not be dependend on Outline module
+  TODO should not be dependent on Outline module
   ## Examples
 
       iex> list_nodes_by_node_container(123)

--- a/lib/radiator/podcast.ex
+++ b/lib/radiator/podcast.ex
@@ -372,7 +372,7 @@ defmodule Radiator.Podcast do
 
   @doc """
   A forced reload of preloaded associations.
-  Usefull when only the associations have changed and Show does need to be reloaded.
+  Useful when only the associations have changed and Show does need to be reloaded.
 
   ## Examples
 
@@ -406,7 +406,7 @@ defmodule Radiator.Podcast do
   end
 
   @doc """
-  Returns the query for list of episodes exluding the once that are marked as deleted.
+  Returns the query for list of episodes excluding the once that are marked as deleted.
 
   ## Examples
 
@@ -435,7 +435,7 @@ defmodule Radiator.Podcast do
   end
 
   @doc """
-  Returns the list of episodes exluding the once that are marked as deleted.
+  Returns the list of episodes excluding the once that are marked as deleted.
 
   ## Examples
 

--- a/test/radiator/outline/validations_test.exs
+++ b/test/radiator/outline/validations_test.exs
@@ -62,7 +62,7 @@ defmodule Radiator.Outline.ValidationsTest do
                Validations.validate_tree_for_container(container_id)
     end
 
-    test "when a parent has two childs with prev_id nil the tree is invalid", %{
+    test "when a parent has two children with prev_id nil the tree is invalid", %{
       nested_node_1:
         %Node{container_id: container_id, parent_id: parent_id} =
           nested_node_1

--- a/test/radiator/outline_test.exs
+++ b/test/radiator/outline_test.exs
@@ -518,7 +518,7 @@ defmodule Radiator.OutlineTest do
 
     # before 1 2 3 4 5
     # after  1 2 4 3 5
-    test "move node 4 within list to node 2, but ommitting the parent_id", %{
+    test "move node 4 within list to node 2, but omitting the parent_id", %{
       node_2: node_2,
       node_3: node_3,
       node_4: node_4,
@@ -588,7 +588,7 @@ defmodule Radiator.OutlineTest do
 
     # before 1 2 3 4 5
     # after  1 3 4 5 2
-    test "move node 2 to the end of the list but ommitting the parent_id", %{
+    test "move node 2 to the end of the list but omitting the parent_id", %{
       node_1: node_1,
       node_2: node_2,
       node_3: node_3,
@@ -636,7 +636,7 @@ defmodule Radiator.OutlineTest do
 
     # before 1 2 3 4 5
     # after  2 3 4 5 1
-    test "move first node to the end of the list and ommitting the parent_id", %{
+    test "move first node to the end of the list and omitting the parent_id", %{
       node_1: node_1,
       node_2: node_2,
       node_3: node_3,
@@ -1051,7 +1051,7 @@ defmodule Radiator.OutlineTest do
   end
 
   describe "outdent_node/1 - simple context" do
-    setup :simple_node_fixture_hierachical
+    setup :simple_node_fixture_hierarchical
 
     test "outdent_node node moves node to same level as previous parent", %{
       node_1: node_1,

--- a/test/radiator/podcast_test.exs
+++ b/test/radiator/podcast_test.exs
@@ -293,7 +293,7 @@ defmodule Radiator.PodcastTest do
       assert nil == Podcast.get_current_episode_for_show(show.id)
     end
 
-    test "get_current_episode_for_show/1 returns episdoe for show" do
+    test "get_current_episode_for_show/1 returns episode for show" do
       episode = episode_fixture()
       assert episode.id == Podcast.get_current_episode_for_show(episode.show_id).id
     end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -76,7 +76,7 @@ defmodule Radiator.DataCase do
     }
   end
 
-  def simple_node_fixture_hierachical(_) do
+  def simple_node_fixture_hierarchical(_) do
     episode = PodcastFixtures.episode_fixture()
 
     attrs = %{


### PR DESCRIPTION
Found via `codespell -S assets,deps -L statics,ist,newyorker` and `typos --hidden --format brief`